### PR TITLE
Added note on using !optional flag when using sass @extend

### DIFF
--- a/docs/syntax/scss.md
+++ b/docs/syntax/scss.md
@@ -110,10 +110,10 @@ If the original selector is not a class selector then the placeholder class can 
         width: 30%;
     }
 
-Modules that make use of styles defined in other modules *must* use those styles by `@extend`ing the appropriate placeholder class:
+Modules that make use of styles defined in other modules *must* use those styles by `@extend`ing the appropriate placeholder class (the `!optional` flag *should* be used to prevent compilation errors if something (e.g. a product developer changing a setting) causes that  placeholder class to be suppressed):
 
     .o-anotherthing-foo, %o-anotherthing-foo {
-        @extend %o-thing-foo;
+        @extend %o-thing-foo !optional;
         margin-top: 1em;
     }
 


### PR DESCRIPTION
I got this error when building o-ft-footer with `$o-grid-is-fixed-desktop: true`; (just doing a local experiment on the module, but the scenario is a valid one as products can set this flag)

> Syntax error: ".o-ft-footer__link-wrapper" failed to @extend "%o-grid-colspan-M6".
>               The selector "%o-grid-colspan-M6" was not found.
>               Use "@extend %o-grid-colspan-M6 !optional" if the extend should be able to fail.

Rather than change o-grid's sass to output dummy, styleless instances of each of its placeholders when they're not required I think a change of the spec is a better option. I've made it a _should_, but it could easily be a _must_
