### PR TITLE
Rule on not using subdependencies directly

### DIFF
--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -112,6 +112,8 @@ Modules *should* have as few subdependencies as possible.  Where the dependency 
 
 If any feature of a dependency's subdepencies are used directly then that subdependency *must* also be added as a direct dependency e.g. if your module has `o-ft-typography` as a dependency but makes use of `oFontsInclude()` in its stylesheets then `o-fonts` must also be added as a dependency.
 
+If a module requires that any feature of its dependencies be used directly by products/components consuming the module then it *should* alias that functionality within its own namespace to avoid them having to include the subdependency as a direct dependency e.g o-ft-typography aliases `oFontsInclude` to `oFtTypographyIncludeFont`.
+
 When listing dependencies in the `dependencies` section of the `bower.json` package configuration, the version requried *must* be specified using an explicit greater-than and less-than pattern, starting with the lowest version that is known to work, and allowing automatic upgrades until the next major version (See [#148](https://github.com/Financial-Times/ft-origami/issues/148))
 
 Where the dependency is an Origami module that is *also a dependency of many other Origami modules*, it *must* verify and assert the widest version compatibility possible, including maintaining compatibility with earlier versions unless to do so would be impractical.


### PR DESCRIPTION
A few modules are including o-ft-typography as a dependency and then using o-colors and o-fonts features directly, which in general isn't a safe pattern, so suggesting this rule to disallow it.

A side-effect of this rule is that many modules will need both o-ft-typography and o-fonts as direct dependencies despite only really being after typography. I suggest o-ft-typography aliases `oFontsInclude()` to `oFtTypographyIncludeFont()`, and perhaps a hint in the specs that module developers should consider aliasing features of dependencies that will need to be accessed by most use cases for their module.
