### PR TITLE
Added reference to handling missing dom nodes gracefully

### DIFF
--- a/docs/syntax/js.md
+++ b/docs/syntax/js.md
@@ -51,7 +51,7 @@ When using selector engines other than native `querySelector`, modules *must not
 
 Modules *may* assume that any HTML markup that relates to their component follows the hierarchical structure specified in their module's Mustache template. However, modules *should not* make assumptions about the order of HTML elements, and should, as far as possible, cope with the presence within the component of elements not specified in the template.
 
-Modules should not throw an error if there are no instances of the module's owned DOM in the page.
+Modules *must* not throw an error if there are no instances of the module's owned DOM in the page.
 
 ## Communicating with host page code and other components
 


### PR DESCRIPTION
When using feature flags in fastft a feature is removed on the fly by setting a mustache variable and hiding the relevant bit of the DOM. This can mean a module's js is included but with no DOM to run on. This rule forces modules to handle that scenario gracefully.
