### PR TITLE
What init methods should do

### DIFF
--- a/docs/syntax/js.md
+++ b/docs/syntax/js.md
@@ -17,10 +17,7 @@ Product developers are encouraged to include Origami JavaScript using a 'cuts th
 
 * Add no objects to the global scope, other than JSONp callback function names.  Variables declared outside of any enclosing function are permitted, provided that the module requires a commonJS interface.  If you don't want to depend on CommonJS, wrap the module in an [IIFE](http://en.wikipedia.org/wiki/Immediately-invoked_function_expression).
 * If the module does not require CommonJS it must include a [Universal Module Definition](https://github.com/umdjs/umd/blob/master/returnExports.js) that includes support for CommonJS.
-* Do not modify the DOM on parse. Instead, where required, export an `init` method. This `init` method:
-	* *should not* require any parameters, and should initialise as many instances of itself as the current DOM requires when called with no parameters e.g. `o-share` will create a share widget for each `<div class="o-share"></div>`	
-	* *should* be bound to an event such as `o.DOMContentLoaded` or `o.load` so it can be auto-invoked ny a product
-	* *may* accept additional parameters which restrict and configure its impact on the page e.g an `el` parameter might limit the module to initialise itself on that element
+* Do not read or modify the DOM on parse
 * If it's possible for the module to create DOM nodes, timers, or otherwise occupy more than a token amount of memory, export a `destroy` method that reverts the module to a pre-`init` state.
 * Do not leave any non-garbage collectable traces after `destroy` is called
 * Do not modify the DOM outside of areas of [owned DOM]({{site.baseurl}}/docs/syntax/html/#owned_dom), except:
@@ -39,6 +36,21 @@ Product developers are encouraged to include Origami JavaScript using a 'cuts th
 	</ul>
 	<p>Where modern browser features might be vendor-prefixed, you can get the correct prefixed version using <a href='https://github.com/Financial-Times/o-useragent'>o-useragent</a>.</p>
 </aside>
+
+## Initialisation
+
+Modules *must* do as little as possible on parse, instead deferring start-up tasks to a publicly exported, static 'init' function that should be either invoked explicitly using the module's API, or automatically by binding to the `o.DOMContentLoaded` or `o.load` events.
+
+Where modules bind to the `o.DOMContentLoaded` or `o.load` events, their `init` method *must* be callable with no arguments (see [issue 228](https://github.com/Financial-Times/ft-origami/pull/228)).
+
+Modules that expose an `init` method or an instance constructor which takes an argument identifying an area of owned DOM *must* allow all of the following types of references:
+
+* An [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) object
+* A string containing a valid querySelector expression, eg ".main-content > [data-o-component~='o-share']"
+* Nothing (or any falsey value), which should be interpreted as `document.body`
+
+Where this reference is passed to an `init` function, the module *may* create multiple instances and return them in an array.  Where passed to a constructor, the module must only create one instance and return it.
+
 
 ## Data attributes
 


### PR DESCRIPTION
I figure developers have a right to know what they can expect an init function to do. As well as the changes in this PR I think we can be even stricter  - which will give us the big win of a standardised API and easier installation - without sacrificing much (because a module _could_ also implement other non-compliant init methods under different names )

I think a good starting principle is that a method _must_ only be called `init` if it can be auto-invoked. Following from that both the _should_ rules in this PR should be changed to _must_.

I think an additional useful convention to enforce would be parameters, vis a vis if an `init` method can take parameters they must be `init(el, conf)` where
- if `el` is a good candidate to be owned DOM (i.e. has class `o-modulename`) then a module instance is created on el
- if `el` is not a good candidate for owned DOM, then a module instance is created for each `el.querySelectorAll('.o-modulename')`
- `conf` accepts equivalents of all configs that can be set using data atttributes (but could also accept additional properties too, so that `init(el, conf)` can give access to an advanced mode ) 
