### PR TITLE
Move browser support into origami.json

### DIFF
--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -186,24 +186,6 @@ Then enable Travis for the project from your [Travis profile page](https://travi
 
 Modules that are not openly published on GitHub *should* use Jenkins for CI.
 
-## Browser support
-
-All modules *must* include documentation that states a mininum version in which the module has been tested, for each of the browser families shown in the example below.  Where a module includes JavaScript, minimum versions should be given for the primary experience and core experience separately.
-
-Example:
-
-<table>
-	<tr><th>Browser</th><th>Min for primary exp.</th><th>Min for core exp.</th></tr>
-	<tr><td>Internet Explorer</td><td>9</td><td>6</td></tr>
-	<tr><td>Firefox</td><td>25</td><td>3</td></tr>
-	<tr><td>Chrome</td><td>10</td><td>1</td></tr>
-	<tr><td>Safari</td><td>5</td><td>2</td></tr>
-	<tr><td>Mobile Safari</td><td>9</td><td>6</td></tr>
-	<tr><td>Mobile Firefox</td><td>9</td><td>6</td></tr>
-	<tr><td>Android browser</td><td>9</td><td>6</td></tr>
-	<tr><td>Opera</td><td>12</td><td>4</td></tr>
-</table>
-
 ## Where to store modules
 
 Modules *must* be stored in git repos with the same name as the module itself.  The host server *must* be one of the following, listed in order of preference (from most preferred to least):

--- a/docs/syntax/origamijson.md
+++ b/docs/syntax/origamijson.md
@@ -92,6 +92,11 @@ All origami components, whether modules or web services, should be discoverable 
 	<td></td>
 	<td></td>
 </tr><tr>
+	<td><code>&nbsp;&nbsp;browserSupport&nbsp;</code></td>
+	<td>object</td>
+	<td>(optional) For modules only, an object identifying browsers that the module has been verified to work in (given the presence of all required polyfills). Each property must have one of the [browser codes defined in o-useragent](https://github.com/Financial-Times/o-useragent) as its key and be an object with two properties - `core` and `primary` - each of which has a numerical value indicating the minimum browser version which supports the core/primary experience for the module.</td>
+</tr><tr>
+</tr><tr>
 	<td><code>&nbsp;&nbsp;serviceUrl</code></td>
 	<td>string</td>
 	<td>(optional) For web services only, the URL on which the service is provided.  Required for web services.</td>


### PR DESCRIPTION
1. Having to write table markup is a pain and registry could easily auto generate a table from json
2. If we want to move towards at least some automated browser testing the browser list will have to be programmatically accessable. 

The json structure I'm proposing isn't much less onerous than table markup, but we could go with some funky minimalist convention e.g.

```
{
   "ie": "7<9"
}
```

to indicate core at 7 and primary at 9. That looks a bit too close to semver for comfort, but I'm sure we could come up with something... maybe `9(7)`
