### PR TITLE
Remove asset paths property from origami.json

### DIFF
--- a/docs/syntax/origamijson.md
+++ b/docs/syntax/origamijson.md
@@ -128,10 +128,6 @@ All origami components, whether modules or web services, should be discoverable 
 	<td>object</td>
 	<td>&nbsp;</td>
 </tr><tr>
-	<td><code>&nbsp;&nbsp;assetPaths</code></td>
-	<td>array</td>
-	<td>(optional) For modules only, an array of glob patterns that specify the locations of public assets within the repository.  Modules *should* provide a list of asset paths if the module uses the `o-assets` asset loader.  If no asset paths are specified, product developers *must* assume that all files in the module may need to be publicly loaded.</td>
-</tr><tr>
 	<td><code>}</code></td>
 	<td></td>
 	<td></td>


### PR DESCRIPTION
We added this a few months ago with the thinking that modules may want to express which paths within the repo that they are likely to make use of as static assets, so that product developers can make only those assets available publicly.  However:
- [No module](https://github.com/search?l=&q=assetpaths+user%3Afinancial-times&ref=advsearch&type=Code&utf8=%E2%9C%93) has actually used this feature.
- It's fragile - you have to remember to update the assetpaths when you add a new asset reference to CSS or JS
- Identifying static assets in CSS can be done more reliably by analysing compiled bundles for which there are [trivial solutions available](https://gist.github.com/parkerl/1771976).
- It adds complexity to Origami, which has a cost

I propose to kill it.  All in favour say merge.
