### PR TITLE
Improve CTM example

### DIFF
--- a/examples/ctm.html
+++ b/examples/ctm.html
@@ -57,7 +57,7 @@
     if (cutsTheMustard) {
       var s = document.createElement('script');
       s.async = s.defer = true;
-      s.src = "//build.origami.ft.com/bundles/js?modules=a,b,c";
+      s.src = '//build.origami.ft.com/bundles/js?modules=a,b,c';
       document.getElementsByTagName('head')[0].appendChild(s);
     }
   </script>


### PR DESCRIPTION
- Add meta and title tags, just to make it look like a valid HTML page (not sure of needed)
- Inject script using `appendChild` instead of a `document.write`
- Wrap text on 80 chars
- Put CTM test in a variable
- Swap the `core` class really early (before CSS is in) to avoid any FOUC
- Shorten the class replacement regex
- Remove unnecessary `type='text/css'` and `type=`text/javascript'`
- Add link to polyfill service documentation

We can discuss the loading method later (script tag vs injection). Interesting article on the subject: https://www.igvita.com/2014/05/20/script-injected-async-scripts-considered-harmful/

I was also tempted of adding this, which probably helps against having a failing CTM:

``` html
<meta http-equiv="X-UA-Compatible" content="IE=Edge">
```
