### PR TITLE
CTM Example: use a more compatible script loading technique

### DIFF
--- a/examples/ctm.html
+++ b/examples/ctm.html
@@ -54,15 +54,15 @@
     - async (modern browsers) and defer (IE 5.5-9) so it is not blocking
   -->
   <script>
-    (function(d) {
+    (function(src) {
       if (cutsTheMustard) {
-        var o = d.createElement('script');
+        var o = document.createElement('script');
         o.async = o.defer = true;
-        o.src = '//build.origami.ft.com/bundles/js?modules=a,b,c';
-        var s = d.getElementsByTagName('script')[0];
+        o.src = src;
+        var s = document.getElementsByTagName('script')[0];
         s.parentNode.insertBefore(o, s);
       }
-    }(document));
+    }('//build.origami.ft.com/bundles/js?modules=a,b,c'));
   </script>
 </head>
 <body>


### PR DESCRIPTION
Use `insertBefore` instead of `appendChild` to load JavaScript from the build service, like all most popular script loaders do (Google Analytics, Twitter widgets, Facebook like button, Disqus comments…).

Also puts it into a self executing anonymous function, which should be much safer than having it in the global scope.

/cc @triblondon 

![ ](http://gifs.joelglovier.com/hubbers/hubmojis-furyus-wink.gif)
