### PR TITLE
Recommend a specific CTM test which meets the FT browser support policy

### DIFF
--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -245,21 +245,9 @@ Modules that are not openly published on GitHub *should* use Jenkins for CI.
 
 ## Browser support
 
-All modules *must* include documentation that states a minimum version in which the module has been tested, for each of the browser families shown in the example below.  Where a module includes JavaScript, minimum versions should be given for the enhanced experience and core experience separately.
+All modules *must* be tested with all the browsers [listed in the FT browser support policy](https://docs.google.com/a/ft.com/document/d/1dX92MPm9ZNY2jqFidWf_E6V4S6pLkydjcPmk5F989YI/edit#heading=h.wcrwnubj26sk), and if a module includes JavaScript, it must be error free in all the browsers that fall above the recommended minimum boundary for enhanced experience in that policy.
 
-Example:
-
-<table>
-	<tr><th>Browser</th><th>Min for enhanced exp.</th><th>Min for core exp.</th></tr>
-	<tr><td>Internet Explorer</td><td>9</td><td>6</td></tr>
-	<tr><td>Firefox</td><td>25</td><td>3</td></tr>
-	<tr><td>Chrome</td><td>10</td><td>1</td></tr>
-	<tr><td>Safari</td><td>5</td><td>2</td></tr>
-	<tr><td>Mobile Safari</td><td>9</td><td>6</td></tr>
-	<tr><td>Mobile Firefox</td><td>9</td><td>6</td></tr>
-	<tr><td>Android browser</td><td>9</td><td>6</td></tr>
-	<tr><td>Opera</td><td>12</td><td>4</td></tr>
-</table>
+The versions tested *should* be listed in the module's documentation, so that when boundary recommendations are changed, it is still possible to determine the support that was designed into an older module.
 
 ## Where to store modules
 

--- a/docs/developer-guide/building-modules.md
+++ b/docs/developer-guide/building-modules.md
@@ -328,21 +328,20 @@ Here's an example of a web page created from the boilerplate that includes the s
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 		<title>Origami template</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	
+
 		<!--
 				Perform your cuts the mustard test.
-				In this case it test for the presence of document.querySelector.
 		-->
 		<script>
-			var cutsTheMustard = 'querySelector' in document;
-	
+			var cutsTheMustard = ('querySelector' in document && 'localStorage' in window && 'addEventListener' in window);
+
 			if (cutsTheMustard) {
 				// Swap the `core` class on the HTML element for an `enhanced` one
 				// We're doing it early in the head to avoid a flash of unstyled content
 				document.documentElement.className = document.documentElement.className.replace(/\bcore\b/g, 'enhanced');
 			}
 		</script>
-	
+
 		<!--
 			Hide any enhanced experience content when in core mode, and vice versa.
 			Add any other inlined CSS here
@@ -351,7 +350,7 @@ Here's an example of a web page created from the boilerplate that includes the s
 			.core .o--if-js,
 			.enhanced .o--if-no-js { display: none !important; }
 		</style>
-	
+
 		<!--
 			This is where your CSS bundle is loaded, and we add any inline CSS
 		-->
@@ -359,7 +358,7 @@ Here's an example of a web page created from the boilerplate that includes the s
 		<style>
 			/* Add any inline CSS here */
 		</style>
-	
+
 		<!--
 			Unconditionally load the polyfill service to provide the best support
 			possible for modern web standards.
@@ -370,7 +369,7 @@ Here's an example of a web page created from the boilerplate that includes the s
 			https://cdn.polyfill.io/
 		-->
 		<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
-	
+
 		<!--
 			Load the main JavaScript bundle asynchronously
 		-->
@@ -387,10 +386,10 @@ Here's an example of a web page created from the boilerplate that includes the s
 		</script>
 	</head>
 	<body>
-	
+
 		<!-- Body content here -->
 		[Find header and footer components from registry.origami.ft.com and put them here]
-	
+
 	</body>
 	</html>
 

--- a/docs/developer-guide/using-modules.md
+++ b/docs/developer-guide/using-modules.md
@@ -51,9 +51,31 @@ The example above uses the [Origami polyfill service](//polyfill.webservices.ft.
 The polyfill service works by reading the `User-Agent` HTTP header on the request from the browser, so users of different browsers will get different responses, which may range in size from several hundred KB to an empty file.
 
 
+### Recommended cuts the mustard test
+
+The current recommended boundary between core and enhanced experience is defined by the following expression:
+
+	'querySelector' in document && 'localStorage' in window && 'addEventListener' in window
+
+This matches the expression published by the BBC in their [original post about CTM](http://responsivenews.co.uk/post/18948466399/cutting-the-mustard), but coverage is now broad enough that we can use it too.  The following browsers (including later versions) pass this test and qualify for enhanced experience:
+
+* IE 9
+* Firefox 3.5
+* Opera 10.5
+* Safari 4
+* iPhone and iPad iOS 1
+* Android phone and tablets 2.1
+* Blackberry OS 6
+* Opera Mobile 11.5
+* Chrome (all)
+* Mobile Firefox (all)
+
+This is a close match for the recommended minimum support in the [FT browser support policy](https://docs.google.com/a/ft.com/document/d/1dX92MPm9ZNY2jqFidWf_E6V4S6pLkydjcPmk5F989YI/edit#heading=h.wcrwnubj26sk).
+
+
 ### Customising your cuts the mustard test
 
-Origami components declare their minimum requirements in terms of [Modernizr](http://modernizr.com/docs/) tests.  Where possible, component developers will currently limit their *required* features to those present or polyfillable in IE9, but they may enhance their component's behaviour using more cutting edge features.  To verify the exact set of browser features required by the set of modules you are using:
+Origami components declare their minimum requirements in terms of [Modernizr](http://modernizr.com/docs/) tests.  Component developers are required to ensure that any JavaScript bundled with their module will run without error in all the browsers that pass the recommended CTM test above, but they may enhance their component's behaviour using more cutting edge features.  To verify the exact set of browser features required by the set of modules you are using:
 
 1. Make an aggregated list of the entries from all the `browserFeatures.required` sections of your chosen modules' [Origami manifest files]({{site.baseurl}}/docs/syntax/origamijson).
 2. Refer to the Modernizr [feature-detects](https://github.com/Modernizr/Modernizr/tree/master/feature-detects) that match the names given in the Origami configs.

--- a/examples/ctm.html
+++ b/examples/ctm.html
@@ -8,12 +8,11 @@
 
 	<!--
 			Perform your cuts the mustard test.
-			In this case it test for the presence of document.querySelector.
 			For information about what features come bundled with other
-			features in all browsers, see http://iwanttouse.com/
+			features in all browsers, see caniuse.com
 	-->
 	<script>
-		var cutsTheMustard = 'querySelector' in document;
+		var cutsTheMustard = ('querySelector' in document && 'localStorage' in window && 'addEventListener' in window);
 
 		if (cutsTheMustard) {
 			// Swap the `core` class on the HTML element for an `enhanced` one


### PR DESCRIPTION
Following Origami meeting last week.

We discussed using `getComputedStyle`, however, that has partial support in fairly old browsers, and is also supported in Opera Mini.  I've instead used the BBC's CTM test from their original post, which is IE9+ and does not include Opera Mini (and also tests features we're more likely to actually need)