### PR TITLE
Remove spurious code

### DIFF
--- a/docs/developer-guide/building-modules.md
+++ b/docs/developer-guide/building-modules.md
@@ -184,9 +184,6 @@ As an example, create a `main.js` file at `/client/js/main.js`, containing:
 	var header = require('o-ft-header');
 
 	// Wait until the page has loaded
-	if (document.readyState === 'interactive' || document.readyState === 'complete') {
-		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-	}
 	document.addEventListener('DOMContentLoaded', function() {
 		// Dispatch a custom event that will tell all required modules to initialise
 		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));


### PR DESCRIPTION
This code seems either incomplete or extraneous if using DOMContentLoaded. If this code is in the head of your document it won't ever evaluate to true. I suggest removing it or perhaps what MDN have as an alternative to DOMContentLoaded:

```javascript
document.onreadystatechange = function () {
  if (document.readyState === "interactive") {
    initApplication();
  }
}
```