### PR TITLE
Add icons and font modules as default modules in the examples

### DIFF
--- a/docs/developer-guide/building-modules.md
+++ b/docs/developer-guide/building-modules.md
@@ -337,8 +337,8 @@ In both cases, (gulp and CLI) this will use origami-build-tools to read your pro
 
 Now, you can simply load the bundles in your web page.  If you saved your bundles to `/public` and that's also the root of your web server, you would write the following HTML:
 
-	<link rel="stylesheet" href="bundle.css" />
-	<script defer async src="bundle.js"></script>
+	<link rel="stylesheet" href="public/bundle.css" />
+	<script defer async src="public/bundle.css"></script>
 
 It's advisable to put the `defer` and `async` attribute on your `<script>` tags, so that loading of the script does not block page load.  Origami components will never require you to load script prior to the DOM being rendered.  See Nicholas Zakas's post [The truth about non blocking JavaScript](http://calendar.perfplanet.com/2010/the-truth-about-non-blocking-javascript/) for more details.
 
@@ -381,7 +381,7 @@ Here's an example of a web page created from the boilerplate that includes the s
 		<!--
 			This is where your CSS bundle is loaded, and we add any inline CSS
 		-->
-		<link rel="stylesheet" href="bundle.css" />
+		<link rel="stylesheet" href="public/bundle.css" />
 		<style>
 			/* Add any inline CSS here */
 		</style>
@@ -409,7 +409,7 @@ Here's an example of a web page created from the boilerplate that includes the s
 					var s = document.getElementsByTagName('script')[0];
 					s.parentNode.insertBefore(o, s);
 				}
-			}('bundle.js'));
+			}('public/bundle.js'));
 		</script>
 	</head>
 	<body>

--- a/docs/developer-guide/building-modules.md
+++ b/docs/developer-guide/building-modules.md
@@ -124,14 +124,17 @@ The packages are listed in *devDependencies* because they are not required to ru
 
 Hopefully you know which Origami modules you want.  If you don't, check out the [Origami registry](http://registry.origami.ft.com) for a list of all our supported components.  You can also add any module from the [bower registry](http://bower.io/search/) that has a [commonJS interface](http://wiki.commonjs.org/wiki/Modules/1.1).
 
-Once you know which Origami modules you want, create a `bower.json` file in the root of your working tree.   This you have to create yourself, and it will be different for each project, but it must conform to the bower [configuration spec](http://bower.io/docs/creating-packages/), which is very similar to npm's config.  Here is an example that includes the o-colors, o-date, o-header and o-footer components:
+Once you know which Origami modules you want, create a `bower.json` file in the root of your working tree.   This you have to create yourself, and it will be different for each project, but it must conform to the bower [configuration spec](http://bower.io/docs/creating-packages/), which is very similar to npm's config.  Here is an example that includes a few key components:
 
 	{
 		"name": "origami-demo",
 		"dependencies": {
-			"o-header": "^2.5.9",
-			"o-footer": "^2.0.1",
-			"o-colors": "^2.4.3"
+			"o-grid": "^3.0.3",
+			"o-header": "^3.0.0",
+			"o-footer": "^3.0.0",
+			"o-colors": "^2.4.7",
+			"o-fonts": "^1.6.7",
+			"o-ft-icons": "^2.3.4"
 		}
 	}
 
@@ -165,18 +168,40 @@ Now you need to create a Sass and/or JavaScript file that requires the Origami c
 
 	@import '{modulename}/main';
 
-As an example (assuming you loaded the header, footer and colours module in your `bowser.json`), create a `main.scss` file at `/client/scss/main.scss` (relative to the root of your working tree), containing:
+As an example (assuming you loaded these modules in your `bowser.json`), create a `main.scss` file at `/client/scss/main.scss` (relative to the root of your working tree), containing:
 
-	/* Import Origami components */
+	// Output grid helper classes and data-attributes
+	$o-grid-is-silent: false;
+	
+	// Output @font-face declarations
+	$o-fonts-is-silent: false;
+	
+	// Output icon helper classes
+	$o-ft-icons-is-silent: false;
+	
+	// Import Origami components
+	@import 'o-grid/main';
+	@import 'o-fonts/main';
+	@import 'o-ft-icons/main';
 	@import 'o-header/main';
 	@import 'o-footer/main';
 	@import 'o-colors/main';
-
-	/* Add our own Sass, using the o-colors module to style the body */
+	
+	// Store the default FT sans-serif font stack in a variable
+	$sans-serif: oFontsGetFontFamilyWithFallbacks(BentonSans);
+	
+	// Set default branding styles
+	html {
+		font-family: $sans-serif;
+		@include oColorsFor(page, background); // The iconic pink background
+	}
+	
+	// Reset the body margins
 	body {
 		margin: 0;
-		@include oColorsFor(page, background);
 	}
+	
+	// Add your own styles here…
 
 The syntax of the JavaSript require is:
 
@@ -332,7 +357,7 @@ Here's an example of a web page created from the boilerplate that includes the s
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 		<!--
-				Perform your cuts the mustard test.
+			Perform your cuts the mustard test.
 		-->
 		<script>
 			var cutsTheMustard = ('querySelector' in document && 'localStorage' in window && 'addEventListener' in window);

--- a/examples/ctm.html
+++ b/examples/ctm.html
@@ -22,12 +22,17 @@
 	</script>
 
 	<!--
-		Hide any enhanced experience content when in core mode, and vice versa.
+		- Hide any enhanced experience content when in core mode, and vice versa.
+		- Set the default font family of the document
 		Add any other inlined CSS here
 	-->
 	<style>
 		.core .o--if-js,
 		.enhanced .o--if-no-js { display: none !important; }
+
+		html {
+			font-family: BentonSans, sans-serif;
+    		}
 	</style>
 
 	<!--

--- a/examples/ctm.html
+++ b/examples/ctm.html
@@ -36,7 +36,7 @@
 		If you have extracted the critical CSS into the inline CSS block above,
 		this could move to the end of the document.
 	-->
-	<link rel="stylesheet" href="//build.origami.ft.com/bundles/css?modules=a,b,c" />
+	<link rel="stylesheet" href="//build.origami.ft.com/bundles/css?modules=o-fonts@^1,o-ft-icons@^2,a,b,c" />
 
 	<!--
 		Unconditionally load the polyfill service to provide the best support


### PR DESCRIPTION
During the workshop we had to tell everybody to load webfonts and icons. That's something we can streamline by putting it by default in the examples that are going to get copy-pasted