### PR TITLE
Remove unnecessary JavaScript and update modules

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
 				var s = document.getElementsByTagName('script')[0];
 				s.parentNode.insertBefore(o, s);
 			}
-		}('//build.origami.ft.com/bundles/js?modules=o-techdocs@^4.0.1'));
+		}('//build.origami.ft.com/bundles/js?modules=o-fonts@^1.6.7,o-techdocs@^4.0.1,o-ft-icons@^2.3.6'));
 	</script>
 
 	<script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
 		}
 	</script>
 
-	<link rel="stylesheet" href="//build.origami.ft.com/bundles/css?modules=o-fonts@^1.6.4,o-techdocs@^4.0.0,o-ft-icons@^2.3.4" />
+	<link rel="stylesheet" href="//build.origami.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-techdocs@^4.0.1,o-ft-icons@^2.3.6" />
 	<link href="{{ site.baseurl }}/buildcache/bundle.css" rel="stylesheet" />
 
 	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
@@ -31,7 +31,7 @@
 				var s = document.getElementsByTagName('script')[0];
 				s.parentNode.insertBefore(o, s);
 			}
-		}('//build.origami.ft.com/bundles/js?modules=o-fonts@^1.6.4,o-techdocs@^4.0.0'));
+		}('//build.origami.ft.com/bundles/js?modules=o-techdocs@^4.0.1'));
 	</script>
 
 	<script>
@@ -190,9 +190,6 @@
 			<p>&copy; THE FINANCIAL TIMES LTD {{ site.time | date:'%Y' }}. FT and 'Financial Times' are trademarks of The Financial Times Ltd.</p>
 		</div>
 	</footer>
-
-	<script src="//cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.js"></script>
-	<script>addEventListener('load', function(event) { prettyPrint(); }, false);</script>
 
 </body>
 </html>


### PR DESCRIPTION
- o-fonts doesn't have any JS
- HighlightJS replaces Prettify for syntax highlighting and is bundled in o-techdocs