### PR TITLE
End chromeframe support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html class="core">
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title>
 		{% if page.title != 'Home' %}{{ page.title }} - {{ site.name }}{% endif %}
 		{% if page.title == 'Home' %}Origami: unifying our brand, making development faster{% endif %}

--- a/docs/developer-guide/building-modules.md
+++ b/docs/developer-guide/building-modules.md
@@ -367,7 +367,7 @@ Here's an example of a web page created from the boilerplate that includes the s
 	<html class="core">
 	<head>
 		<meta charset="utf-8" />
-		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<title>Origami template</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/docs/developer-guide/general-best-practices.md
+++ b/docs/developer-guide/general-best-practices.md
@@ -87,7 +87,7 @@ Use an HTML5 DOCTYPE, and add the `X-UA-Compatible` meta tag to force Internet E
 	<html>
 	<head>
 	   ...
-	   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+	   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
 
 ###Use UTF-8

--- a/examples/ctm.html
+++ b/examples/ctm.html
@@ -2,7 +2,7 @@
 <html class="core">
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title>Origami template</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 


### PR DESCRIPTION
See http://www.google.com/chromeframe/about/:

> Thank you for stopping by
> 
> We've wound down Chrome Frame and ceased support. Please read our previous announcement for more information. If you haven't already, consider installing and using a modern browser to get the best of the web.
> 
> For more developer information please see the FAQ.
> 
> Sincerely,
> 
> The Google Chrome Frame team