### PR TITLE
Fix small issues in documentation pages

### DIFF
--- a/docs/3rd-party-a-list.md
+++ b/docs/3rd-party-a-list.md
@@ -24,7 +24,7 @@ Origami components may have dependencies (via Bower) on third party components. 
 		<td>AJAX</td>
 		<td><a href="https://github.com/whatwg/fetch">fetch</a></td>
 		<td>jQuery, superagent</td>
-		<td>Components should <a href="#why_not_jquery">not use jQuery</a>, fetch is better and will be supported natively by browsers.  In the meantime a [polyfill exists](https://github.com/github/fetch) and is [available through the Polyfill Service](https://cdn.polyfill.io/).</td>
+		<td>Components should <a href="#why_not_jquery">not use jQuery</a>, fetch is better and will be supported natively by browsers.  In the meantime a <a href="https://github.com/github/fetch">polyfill exists</a> and is <a href="https://cdn.polyfill.io/">available through the Polyfill Service</a>.</td>
 	</tr><tr>
 		<td>Event delegation</td>
 		<td><a href="https://github.com/ftlabs/ftdomdelegate">ftdomdelegate</a></td>
@@ -34,7 +34,7 @@ Origami components may have dependencies (via Bower) on third party components. 
 		<td>JavaScript utils</td>
 		<td><a href="https://github.com/lodash/lodash-node">Lodash-node</a></td>
 		<td>Underscore, Lodash</td>
-		<td>Lodash is roughly functionally equivalent to Underscore, but generally delivers faster performance, and includes some useful things not available in Underscore. Lodash-node has the additional benefit of making each method individually requireable (the 'modern' version of its methods are preferred) e.g. `require('lodash-node/modern/functions/throttle')`</td>
+		<td>Lodash is roughly functionally equivalent to Underscore, but generally delivers faster performance, and includes some useful things not available in Underscore. Lodash-node has the additional benefit of making each method individually requireable (the 'modern' version of its methods are preferred) e.g. <code>require('lodash-node/modern/functions/throttle')</code></td>
 	</tr><tr>
 		<td>Template engine</td>
 		<td><a href="https://github.com/twitter/hogan.js">Hogan</a></td>

--- a/docs/developer-guide/general-best-practices.md
+++ b/docs/developer-guide/general-best-practices.md
@@ -119,7 +119,7 @@ ARIA is a set of accessibility standards that allow users of assistive technolog
 	<li aria-selected="true">I'm selected</li>
 	<li aria-selected="false">I'm not selected, but am selectable</li>
 
-Some states are automatically recognised by the browser and you don't need to do anything to enable them, such as **hovered** and **focused**, but it is possible to break the browser's behaviour (e.g. by setting a CSS `outline: none` property).  In the particular case of focus, please allow the browser to apply it's default focus style if possible.
+Some states are automatically recognised by the browser and you don't need to do anything to enable them, such as **hovered** and **focused**, but it is possible to break the browser's behaviour (e.g. by setting a CSS `outline: none` property).  In the particular case of focus, please allow the browser to apply its default focus style if possible.
 
 Some Origami components may not display correctly unless you apply the right state attributes.
 

--- a/docs/syntax/js.md
+++ b/docs/syntax/js.md
@@ -59,7 +59,7 @@ If you do copy a reference to `this` into a separate variable, make it semantic:
 <?prettify?>
 	var post = this;
 
-<aside>ES6 offers lexical <code>this</code> binding as part of arrow functions, which provides a much more elegant solution to this problem, but currently we require Origami code to be written in ES5 syntax.  ES6 methods that can be polyfilled by the [polyfill service](https://cdn.polyfill.io) down to IE9 **may** be used (e.g. Promises), provided the component [declares each feature in the `browserFeatures` section of its `origami.json` file](http://origami.ft.com/docs/syntax/origamijson/#format).</aside>
+<aside>ES6 offers lexical <code>this</code> binding as part of arrow functions, which provides a much more elegant solution to this problem, but currently we require Origami code to be written in ES5 syntax.  ES6 methods that can be polyfilled by the <a href="https://cdn.polyfill.io">polyfill service</a> down to IE9 <em>may</em> be used (e.g. Promises), provided the component <a href="http://origami.ft.com/docs/syntax/origamijson/#format">declares each feature in the <code>browserFeatures</code> section of its <code>origami.json</code> file</a>.</aside>
 
 
 
@@ -239,7 +239,7 @@ This makes diffs easier to read, and reduces the chance of errors associated wit
 
 ###Comments
 
-Single line comments *should* be placeed on a newline above the subject of the comment.  An empty line *should* be inserted before the comment.
+Single line comments *should* be placed on a newline above the subject of the comment.  An empty line *should* be inserted before the comment.
 
 
 ## Subresources

--- a/docs/syntax/scss.md
+++ b/docs/syntax/scss.md
@@ -29,7 +29,7 @@ Sass does not have proper encapsulation or scope, so strict adherence to namespa
 
 * Class selectors (`.`) and Sass variables (`$`) *must* be prefixed with the module name, and written as hyphen separated lowercase strings
 	- GOOD: `.o-thing--large`, `$o-grid-mq-type: width;`
-	- BAD: `.largething`, '$GridIsResponsive: true;'
+	- BAD: `.largething`, `$GridIsResponsive: true;`
 * Pseudo class `:not` *should not* be used to avoid high specificity issues. Prefer classes and duplicated properties over specificity.
 	- GOOD: `.o-forms-input {} .o-forms-radio {}`
 	- BAD: `.o-forms-input {} .o-forms-input:not([type=radio]) {} .o-forms-input[type=radio] {}`

--- a/docs/syntax/web-service-description.md
+++ b/docs/syntax/web-service-description.md
@@ -7,7 +7,7 @@ permalink: /docs/syntax/web-service-description/
 
 # Web service description format
 
-All Origami web services are required to expose `/{version}/__about` endpoints to describe each version of the service.  The response give at this URL must be a JSON document conforming to the following format.
+All Origami web services are required to expose `/{version}/__about` endpoints to describe each version of the service.  The response given at this URL must be a JSON document conforming to the following format.
 
 ## Format
 

--- a/docs/syntax/web-service-index.md
+++ b/docs/syntax/web-service-index.md
@@ -7,7 +7,7 @@ permalink: /docs/syntax/web-service-index/
 
 # Web service index format
 
-All Origami web services are required to expose an `/__about` endpoint to list the available versions of the service.  The response give at this URL must be a JSON document conforming to the following format.
+All Origami web services are required to expose an `/__about` endpoint to list the available versions of the service.  The response given at this URL must be a JSON document conforming to the following format.
 
 ## Format
 


### PR DESCRIPTION
I've been reading through the documentation and I found a few minor issues (which are a lot easier to spot to a fresh pair of eyes) that I thought I should point out.

In this PR, I've included the trivial things that I was able to fix myself (mostly related to Markdown parsing and a couple of typos), but there are a couple of others that would require further information and decisions from you.

1. In [General best practices](http://origami.ft.com/docs/developer-guide/general-best-practices/#browser-support), there's a link to a private [Google Docs file](https://docs.google.com/a/ft.com/document/d/1dX92MPm9ZNY2jqFidWf_E6V4S6pLkydjcPmk5F989YI/edit), not sure if intentionally;
1. In [Core vs Enhanced experience](http://origami.ft.com/docs/developer-guide/using-modules/#core-vs-enhanced-experience), the *Mustache as a spec* section has an empty link to *HTML imports* (which would also need to be converted to an `<a>` tag because it's wrapped in HTML);
1. In [Sass, Feature flags](http://origami.ft.com/docs/syntax/scss/#feature-flags) the code snippets aren't being formatted. There's a [known issue](https://github.com/jekyll/jekyll/issues/588) with code blocks breaking ordered lists, so not sure how would you like to tackle it.

Hope this helps!