### PR TITLE
Fixing the anchor links in the 3rd-party A list

### DIFF
--- a/docs/3rd-party-a-list.md
+++ b/docs/3rd-party-a-list.md
@@ -19,17 +19,17 @@ Origami components may have dependencies (via Bower) on third party components. 
 		<td>DOM manipulation</td>
 		<td>o-dom (TBC)</td>
 		<td>jQuery<br/>Mootools<br/>Dojo<br/>Prototype<br/>YUI</td>
-		<td>A general purpose DOM manipulation library is invariably a common request, but large DOM libraries should be avoided since they contain numerous other features beyond simple DOM manipulation.  See also <a href="#why_not_jquery">Why not jQuery</a></td>
+		<td>A general purpose DOM manipulation library is invariably a common request, but large DOM libraries should be avoided since they contain numerous other features beyond simple DOM manipulation.  See also <a href="#why-not-jquery">Why not jQuery</a></td>
 	</tr><tr>
 		<td>AJAX</td>
 		<td><a href="https://github.com/whatwg/fetch">fetch</a></td>
 		<td>jQuery, superagent</td>
-		<td>Components should <a href="#why_not_jquery">not use jQuery</a>, fetch is better and will be supported natively by browsers.  In the meantime a <a href="https://github.com/github/fetch">polyfill exists</a> and is <a href="https://cdn.polyfill.io/">available through the Polyfill Service</a>.</td>
+		<td>Components should <a href="#why-not-jquery">not use jQuery</a>, fetch is better and will be supported natively by browsers.  In the meantime a <a href="https://github.com/github/fetch">polyfill exists</a> and is <a href="https://cdn.polyfill.io/">available through the Polyfill Service</a>.</td>
 	</tr><tr>
 		<td>Event delegation</td>
 		<td><a href="https://github.com/ftlabs/ftdomdelegate">ftdomdelegate</a></td>
 		<td>jQuery</td>
-		<td>Components should <a href="#why_not_jquery">not use jQuery</a>.</td>
+		<td>Components should <a href="#why-not-jquery">not use jQuery</a>.</td>
 	</tr><tr>
 		<td>JavaScript utils</td>
 		<td><a href="https://github.com/lodash/lodash-node">Lodash-node</a></td>


### PR DESCRIPTION
Kramdown Markdown parser generates anchors using dashes