### PR TITLE
Correct emphasis

### DIFF
--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -141,7 +141,7 @@ Theming classes *must* be applied to the root element of the component to be the
 * *Must* include an `ignore` property listing all files and directories in the module that are not required by product developers, which *must* include anything that is not declarative code or front end JavaScript.  The `origami.json` and `README.md` files, and any demo files, *should not* be ignored, since they may be needed by Origami-aware tools that install and catalogue Origami modules.
 * *May* include `devDependencies` if appropriate
 * *Must not* include a `version` property.  The version property is not needed and risks being out of sync with the repo tag
-* *Should* not include anything else
+* *Should not* include anything else
 
 The following is an example `bower.json` file that meets the above spec:
 
@@ -234,7 +234,7 @@ then it *may* be omitted from the dependency list and not imported at build time
 
 ## Tests and demos
 
-Components *should* include tests which at least verify that the component can be built using [origami-build-tools](https://github.com/Financial-Times/origami-build-tools). Component authors *may* additionally test their component however they like, provided that all test related files *should* be in the `tests` directory, and that test related files *must* not be installable.  The source files of the component *should* be in `src` (except the main JS and/or Sass file).  The project *must* contain a `README.md` formatted in markdown.
+Components *should* include tests which at least verify that the component can be built using [origami-build-tools](https://github.com/Financial-Times/origami-build-tools). Component authors *may* additionally test their component however they like, provided that all test related files *should* be in the `tests` directory, and that test related files *must not* be installable.  The source files of the component *should* be in `src` (except the main JS and/or Sass file).  The project *must* contain a `README.md` formatted in markdown.
 
 Component authors *may* include a `demos` folder to provide examples.  Demos *must* be created using [origami-build-tools](https://github.com/Financial-Times/origami-build-tools), and *must* be compatible with the demo viewer in the Origami registry.  Demos *must* include only the minimum amount of content to show the component, and particularly should not include any headings, backgrounds, margins or other content that are not part of the component itself, unless absolutely essential to the ability to demonstrate the component.
 

--- a/docs/component-spec/web-services.md
+++ b/docs/component-spec/web-services.md
@@ -103,7 +103,7 @@ If a web service has two versions, `v1` and `v2`, there *must* be three of each 
 
 ### De-duplication of output
 
-Web service components *should* not offer any de-duplication of content.  If a product developer wants to draw from multiple Origami sources, and de-dupe where the same individual content item may appear from more than one of those sources, that's not a problem that Origami will solve for them, but could be solved at the product level by consuming data rather than markup.
+Web service components *should not* offer any de-duplication of content.  If a product developer wants to draw from multiple Origami sources, and de-dupe where the same individual content item may appear from more than one of those sources, that's not a problem that Origami will solve for them, but could be solved at the product level by consuming data rather than markup.
 
 ## Metrics
 

--- a/docs/syntax/html.md
+++ b/docs/syntax/html.md
@@ -35,9 +35,9 @@ Where Origami components include or output HTML, it should meet the following re
 	* `<base>`
 	* `<link>`
 	* `<noscript>`
-* Those elements and attributes which are deprecated in the HTML5 spec *should* not be used:
+* Those elements and attributes which are deprecated in the HTML5 spec *should not* be used:
 	- BAD: `<applet>`, `<frameset>`, `<font>`, `<link rev="">`, `<td align="right">`
-* `<iframe>` *must* not be used in markup. Iframes may be created by JavaScript.
+* `<iframe>` *must not* be used in markup. Iframes may be created by JavaScript.
 * Conditional comments *must not* be used in components or recommended to product developers. Components should instead rely on classes on the `html` element that indicate feature support. Component authors may require the product application to set any feature support classes supported by [Modernizr](http://modernizr.com/docs/). Product developers may of course choose to apply those classes using conditional comments.
 * HREFs in markup *must not* use the `javascript:` protocol.
 * The following **attributes** must not be present on any element:

--- a/docs/syntax/js.md
+++ b/docs/syntax/js.md
@@ -128,7 +128,7 @@ When using selector engines other than native `querySelector`, modules *must not
 
 Modules *may* assume that any HTML markup that relates to their component follows the hierarchical structure specified in their module's Mustache template. However, modules *should not* make assumptions about the order of HTML elements, and should, as far as possible, cope with the presence within the component of elements not specified in the template.
 
-Modules *must* not throw an error if there are no instances of the module's owned DOM in the page.
+Modules *must not* throw an error if there are no instances of the module's owned DOM in the page.
 
 ## Communicating with host page code and other components
 
@@ -224,7 +224,7 @@ Overwriting the prototype wipes out the `constructor` property and makes inherit
 
 ## Animation
 
-Modules *must not* animate elements using methods that do not utilise hardware acceleration if hardware accelerated alternatives are available.  For example, repositioning an element repeatedly using its `left` or `top` CSS properties is not allowed.  Instead, use [CSS transitions](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Using_CSS_transitions) and [`will-change`](http://tabatkins.github.io/specs/css-will-change/).  On user agents that do not support accelerated animation, animation *should* not be used.
+Modules *must not* animate elements using methods that do not utilise hardware acceleration if hardware accelerated alternatives are available.  For example, repositioning an element repeatedly using its `left` or `top` CSS properties is not allowed.  Instead, use [CSS transitions](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Using_CSS_transitions) and [`will-change`](http://tabatkins.github.io/specs/css-will-change/).  On user agents that do not support accelerated animation, animation *should not* be used.
 
 ## Feature stability
 

--- a/docs/syntax/scss.md
+++ b/docs/syntax/scss.md
@@ -193,8 +193,8 @@ Component developers *must not* use [IE conditional comments](http://www.quirksm
 
 ##Values
 
-* Component CSS *should* not use `!important`.  Valid use cases for `!important` exist, but usually only at the product level.  If `!important` is used in a component, a comment *must* be left in code to explain why it was necessary.
-* CSS expressions and behaviours *should* not be used, except to polyfill essential features for older browsers (e.g. boxsizing.htc for `box-sizing: border-box`)
+* Component CSS *should not* use `!important`.  Valid use cases for `!important` exist, but usually only at the product level.  If `!important` is used in a component, a comment *must* be left in code to explain why it was necessary.
+* CSS expressions and behaviours *should not* be used, except to polyfill essential features for older browsers (e.g. boxsizing.htc for `box-sizing: border-box`)
 * Lengths *should* be expressed in pixel or percentage units, not ems or rems, with the exception of `line-height` which also accepts unitless values. A comment *should* be left in code when modern (`vh`, `vw`…) or relative units (`em`…) are used to document their purpose.
 
 ##No @extends for foreign selectors


### PR DESCRIPTION
According to RFC2119 SHOULD NOT has a particular meaning and so I think both
"should" and "not" should be emphasized here rather than just "should"