### PR TITLE
Fix broken mark down / typo

### DIFF
--- a/docs/developer-guide/general-best-practices.md
+++ b/docs/developer-guide/general-best-practices.md
@@ -8,7 +8,7 @@ site_section: developer-guide
 
 # General best practices for front end development
 
-Origami requires a high standard of developers who make components for use by others, but many of these same rules are just good practices for anyone that builds websites using the web technologies of HTML, CSS and JavaScript.  If you are building an FT site, please use the following checklist for up to date guidance on the best practies you should be following in your web development.
+Origami requires a high standard of developers who make components for use by others, but many of these same rules are just good practices for anyone that builds websites using the web technologies of HTML, CSS and JavaScript.  If you are building an FT site, please use the following checklist for up to date guidance on the best practices you should be following in your web development.
 
 In addition to the rules below, the [Google Web Fundamentals documentation](https://developers.google.com/web/fundamentals) is a good resource for developing best practices.
 

--- a/docs/developer-guide/general-best-practices.md
+++ b/docs/developer-guide/general-best-practices.md
@@ -12,7 +12,7 @@ Origami requires a high standard of developers who make components for use by ot
 
 In addition to the rules below, the [Google Web Fundamentals documentation](https://developers.google.com/web/fundamentals) is a good resource for developing best practices.
 
-##Browser support
+## Browser support
 
 Conform to the [FT Browser support standard](https://docs.google.com/a/ft.com/document/d/1dX92MPm9ZNY2jqFidWf_E6V4S6pLkydjcPmk5F989YI/edit).  In principle this means that your site will:
 
@@ -21,7 +21,7 @@ Conform to the [FT Browser support standard](https://docs.google.com/a/ft.com/do
 * Present a consistent, functional and high quality experience to users in both core and enhanced experience
 
 
-##Design
+## Design
 
 Although you may spend most of your time on your own product, remember that our readers move from one FT product to another all the time, and we need to make their life as easy as possible by offering a <strong>consistent brand experience</strong>.  Consider the following points when you are making your product:
 
@@ -29,9 +29,9 @@ Although you may spend most of your time on your own product, remember that our 
 * Are you using standard brand assets like the FT logo, social media network icons, headshots of FT journalists or font files?  You must use the correct versions of these, available from the [data sets](http://git.svc.ft.com/projects/DATA) collection of repos in Stash.  In many cases it's a lot easier to retrieve these files though the [build service](http://build.origami.ft.com) or [image service](http://image.webservices.ft.com), rather than hosting them within your product.  That way, you can be sure you're using the right one.
 
 
-##Images
+## Images
 
-###Format and scale images correctly
+### Format and scale images correctly
 
 There are a number of best practices to observe on the use of images:
 
@@ -42,33 +42,33 @@ There are a number of best practices to observe on the use of images:
 * Use the Origami [image service](http://image.webservices.ft.com) to rescale your images dynamically based on the size of the container.
 
 
-##Performance
+## Performance
 
-###Audit with PageSpeed
+### Audit with PageSpeed
 
 Use Google's [PageSpeed Insights](http://developers.google.com/speed/pagespeed/insights) service to analyse your page and try to score at least 80 on both the mobile and desktop categories.  This will cover off a wide variety of performance related best practices, including minification and concatenation of assets, image sizing and avoiding subresource requests that block rendering.
 
-###Use the polyfill service
+### Use the polyfill service
 
 The [Origami polyfill service](http://polyfill.webservices.ft.com) creates custom bundles of polyfills based on the exact requirements of the user's browser, so we can avoid serving unnecessary code to browsers that already support a feature natively, but we can automatically upgrade browsers that don't support the feature.
 
 This means you can assume modern web standards, you don't have to bundle any polyfills with your code, and performance on modern browsers is great - they get an empty file.
 
-###Use responsive images
+### Use responsive images
 
 Don't download large images and then display them at a tiny size.  See [Images](#images).
 
 
-##Security
+## Security
 
-###Don't collect data on insecure pages
+### Don't collect data on insecure pages
 
 When prompting the user for personal data such as email address, username, password or payment information, always serve the page with the form on it using HTTPS, and send the form submission to an HTTPS URL.
 
 It's often considered OK to serve forms on insecure pages as long as the form posts to a secure destination.  This is not acceptable, because an attacker can modify the page that serves the form, to simply change the form post destination.  For more information, see [Steal my login](http://www.stealmylogin.com/).
 
 
-##Accessibility
+## Accessibility
 
 Not only is it a legal requirment to make reasonable adjustments to accomodate the needs of disabled readers, it also provides SEO benefits, and generally makes life easier for everyone.  Consider the following points:
 
@@ -77,9 +77,9 @@ Not only is it a legal requirment to make reasonable adjustments to accomodate t
 * Always provide text alternatives to images or an empty `alt` if the image is not content
 
 
-##HTML
+## HTML
 
-###Trigger standards mode
+### Trigger standards mode
 
 Use an HTML5 DOCTYPE, and add the `X-UA-Compatible` meta tag to force Internet Explorer not to use compatibility mode.
 
@@ -91,7 +91,7 @@ Use an HTML5 DOCTYPE, and add the `X-UA-Compatible` meta tag to force Internet E
 	   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
 
-###Use UTF-8
+### Use UTF-8
 
 Character encoding can cause problems, especially on sites that are predominently in English with a few foreign characters here and there, where issues with character encoding can easily go unnnoticed.
 
@@ -102,7 +102,7 @@ Ensure that your pages are **UTF-8** encoded, using both an HTTP response header
 
 Place this as the first tag within the `<head>` section of the page, before `<title>`, since it's important that the browser knows the right character set to use before it gets to any content.
 
-###Use correct viewport sizing
+### Use correct viewport sizing
 
 By default, most mobile devices assume your site won't fit on a small screen so will pretend to be 900px wide and zoom out so that that fits on the screen.  Add the following viewport meta tag to the `<head>` of your page to make sure that the viewport is zoomed to 100% and the width is the same as the width of the device in both portrait and landscape orientation:
 
@@ -112,7 +112,7 @@ By default, most mobile devices assume your site won't fit on a small screen so 
 Do **not** specify a `user-scalable` rule.  The default is yes, so there's no need to include it, and the user should always be allowed to zoom if they want to.
 
 
-###Use ARIA for state
+### Use ARIA for state
 
 ARIA is a set of accessibility standards that allow users of assistive technologies to get a better experience of the web.  It is important not only that you correctly flag when a state exists on an object, but that you choose the right state label, and you apply it using the right ARIA attribute.  Examples of states that you need to flag manually in your markup are **busy**, **selected** and **invalid**.
 
@@ -128,21 +128,21 @@ Some Origami components may not display correctly unless you apply the right sta
 * [ARIA states and properties specification](http://www.w3.org/TR/wai-aria/states_and_properties) (W3C)
 
 
-###Validate your code
+### Validate your code
 
 Run your fully assembled page through the [W3C validator](http://validator.w3.org/) to ensure you don't have any invalid code.  Origami components should have no invalid code, so if you find any please raise a bug.
 
 
-##CSS
+## CSS
 
-###Lint your code
+### Lint your code
 
 Consider running [SCSS-Lint](https://github.com/causes/scss-lint) or CSSlint on your CSS.  The syntax standards used by Origami are a good set of rules to use:
 
 * [Origami Sass syntax standard]({{site.baseurl}}/docs/syntax/scss/#syntax-convention-rules)
 
 
-###Minimise CSS specificity
+### Minimise CSS specificity
 
 CSS selectors have a heirarchy of specificity, which can lead to 'specificity wars', especially in products that are maintained by multiple non-collaborating teams.  Avoid these problems by following CSS best practices:
 
@@ -153,12 +153,12 @@ CSS selectors have a heirarchy of specificity, which can lead to 'specificity wa
 * [Learn about BEM (block element modifier)](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/)
 
 
-###Measure lengths in pixels
+### Measure lengths in pixels
 
 All Origami components use pixels for length measures.  To avoid incompatibilities, and because relative measures such as ems result in over-complicated calculations, we recommend using pixels for lengths.
 
 
-###Use standard colour palette
+### Use standard colour palette
 
 The FT standard colour palette is available as an Origami component, [o-colors](http://registry.origami.ft.com/components/o-colors).  Use use cases rather than palette colours, adding your own use cases where needed.  If you are using Sass, avoid including any raw colour values in your Sass, except as part of defining new colour use cases.
 
@@ -167,7 +167,7 @@ Information about how to use o-colors is available in the docs:
 * [Learn about o-colors](http://registry.origami.ft.com/components/o-colors)
 
 
-###Turn off hover effects when appropriate
+### Turn off hover effects when appropriate
 
 If the user is on a touchscreen device and does not have a mouse or similar device connected, there will be no on-screen mouse cursor.  Hover effects are unnecessary in these situations, and can degrade the user experience on devices which [emulate hover](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html).
 
@@ -176,21 +176,21 @@ Equally, when a user is scrolling, hover effects can be unintentionally triggere
 Consider using [o-hoverable](http://registry.origami.ft.com/components/o-hoverable), which intelligently flags when hover effects are desiriableby toggling a class on the `<html>` element.
 
 
-###Choose breakpoints based on content
+### Choose breakpoints based on content
 
 Your styles should allow content to fit on screens down to around 300px wide.  In choosing breakpoints for style changes as the screen gets larger, you should not take any interest in the widths of devices in use.  It may be that turning a device from portrait to landscape view activates a different media query and displays the medium width layout.  Don't try to prevent this happening - it's a correct and inevitable result of well chosen breakpoints.
 
 
-##JavaScript
+## JavaScript
 
-###Lint your code
+### Lint your code
 
 Consider running [ESLint](http://www.eslint.org/) over your JavaScript.  The syntax standards used by Origami are a good set of rules to use:
 
 * [Origami JavaScript syntax standard]({{site.baseurl}}/docs/syntax/js/#syntax-convention-rules)
 
 
-###Do not rely on JavaScript for navigation
+### Do not rely on JavaScript for navigation
 
 Don't create links with `javascript:` prefixes in the href unless those links are not relevant to navigating the site.  Any UI element that appears to be navigation should have a real href.
 

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -6,17 +6,17 @@ permalink: /docs/developer-guide/
 site_section: developer-guide
 ---
 
-#Developer guide
+# Developer guide
 
 When you're building a new web product, chances are you need a lot of stuff that's common across many FT sites.  Origami **modules** provide you with common functional components, behaviours, layouts and styles, while Origami **web services** provide dynamic data services and markup feeds.
 
-##Web services
+## Web services
 
 Web services all share a common, recognisable pattern.  For more information on use of web services, consult the web services guide:
 
 * [Using web services](web-services)
 
-##Modules
+## Modules
 
 Modules are more complicated, since they offer units of code that can be integrated into your application.
 
@@ -33,7 +33,7 @@ Once you know which modules you want to use, consult the using modules guide for
 * [Using modules](using-modules)
 
 
-##General best practices
+## General best practices
 
 The information included in this guide will help you use Origami components without the need to really understand their internals.  But since these components follow rigorous standards and implement modern best practices for accessibility, security, maintainability and performance, we also offer a summary checklist of the most important points so you can meet the same standards in your own code.
 

--- a/docs/syntax/js.md
+++ b/docs/syntax/js.md
@@ -38,7 +38,7 @@ Product developers are encouraged to include Origami JavaScript using a 'cuts th
 	<p>Where modern browser features might be vendor-prefixed, you can get the correct prefixed version using <a href="https://github.com/Financial-Times/o-useragent">o-useragent</a>.</p>
 </aside>
 
-###Scoping and binding `this`
+### Scoping and binding `this`
 
 The value of `this` *should not* be copied into non-semantic variables such as `that`, `self` or `_this` in order to embed a child funtion context.  Instead, either use a semantic name, or bind the correct value of `this`.  Some object methods accept the intended value of `this` as an argument, such as [Array.prototype.filter](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), and this method *should* be considered most preferred:
 
@@ -199,7 +199,7 @@ Modules that store data on the client via user-agent APIs *must* encapsulate all
 
 Modules *should* avoid containing functions with more than 3 arguments.  Where more parameters are required, consider passing an object (and if so, consider using [lo-dash's defaults function](http://lodash.com/docs#defaults)).
 
-##Objects
+## Objects
 
 Object properties *must not* be named after reserved words in the JavaScript language.  ([Learn more](https://github.com/airbnb/javascript/issues/61))
 
@@ -246,7 +246,7 @@ JavaScript *must* be linted with [ESLint](http://www.eslint.org/).  If you wish 
 
 Developers *should* stick to the above `.eslintrc` config, since this represents a common standard across FT teams, but are permitted to make changes if desired.  In addition to the ESLint rules:
 
-###Comments
+### Comments
 
 Single line comments *should* be placed on a newline above the subject of the comment.  An empty line *should* be inserted before the comment.
 

--- a/docs/syntax/scss.md
+++ b/docs/syntax/scss.md
@@ -6,25 +6,25 @@ permalink: /docs/syntax/scss/
 site_section: about-origami
 ---
 
-#SCSS standards
+# SCSS standards
 
 Origami has adopted [Sass](http://sass-lang.com/) and specifically the most common SCSS variant, as the preferred way of declaring style information.  The following rules apply to creating styles for **components**, but could also be adopted in large part for product developers.
 
 Sass features should be used only where they result in increased clarity and reuse. Care should be taken that the resulting CSS is not compromised by unnecessary Sass nesting.
 
-##Sass version
+## Sass version
 
 Component developers and Origami build tools *must* use LibSass version ~3.2.0.
 
-##Syntax convention rules
+## Syntax convention rules
 
 Sass *must* validate using the following [SCSS-lint](https://github.com/causes/scss-lint) rules:
 
 <div class="o-techdocs-gist" data-repo="Financial-Times/origami-build-tools" data-path="/config/scss-lint.yml"></div>
 
-##Selectors
+## Selectors
 
-###Naming conventions and encapsulation
+### Naming conventions and encapsulation
 
 Sass does not have proper encapsulation or scope, so strict adherence to namespacing rules is essential.
 
@@ -48,7 +48,7 @@ Sass does not have proper encapsulation or scope, so strict adherence to namespa
 	* have an existing class in the module's namespace.
 
 
-###Specificity
+### Specificity
 
 * Specificity *must* be minimised. Use [BEM](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/), especially if the component might contain other components (e.g. in the case of a 'grid' component), to avoid one component's styles affecting the appearance of a component within it.  Where a component can never contain any child components (e.g. a 'tweet' component or a 'gallery' component), they may instead choose to use simple class names and increase specificity with the module root selector as a parent.
 * Selectors *should* contain a single operand, with the following exceptions:
@@ -65,7 +65,7 @@ Sass does not have proper encapsulation or scope, so strict adherence to namespa
 * Increased specificity *must not* be used to overcome an existing overly-specific selector - make the existing one less specific, or use new class names.
 
 
-###State
+### State
 
 [ARIA roles](http://www.w3.org/TR/wai-aria/states_and_properties) *should* be used to indicate state, except where state is switched automatically by the browser and selectable using pseudo-classes.  The following states *should* be considered:
 
@@ -138,11 +138,11 @@ Sass does not have proper encapsulation or scope, so strict adherence to namespa
 By default, a module's style rules *must* render it in a form suitable for use without JavaScript (which may involve hiding it completely). Any modifications to that style which are desired if the JavaScript component of the module is present must be prefixed with `.o-modulename--js`.
 
 
-###Feature flags and UA targeting
+### Feature flags and UA targeting
 
 Style rules that are intended to apply to only a subset of user agents *should* use feature flags to apply the rules (which is a progressive enhancement technique).  Where feature flagging is not possible, developers *may* choose to target specific user agents (a graceful degradation technique).
 
-####Feature flags
+#### Feature flags
 
 The following are acceptable types of feature flag, in order of preference:
 
@@ -170,7 +170,7 @@ The following are acceptable types of feature flag, in order of preference:
 Component developers *must not* use feature flags that would need to be set manually by a product developer (ie those that do not have feature detect code within Modernizr or feature-detection modules in Origami).  Component developers *must* assume that feature flag classes will be set on the `documentElement`, ie. the HTML tag.
 
 
-####UA targeting
+#### UA targeting
 
 Where necessary, components *may* provide style rules targeted at specific user agents.
 
@@ -192,19 +192,19 @@ In order of preference, when targeting styles at a specific user agent, componen
 
 Component developers *must not* use [IE conditional comments](http://www.quirksmode.org/css/condcom.html) to target user agents (use [browser hacks](http://browserhacks.com/) instead).
 
-##Values
+## Values
 
 * Component CSS *should not* use `!important`.  Valid use cases for `!important` exist, but usually only at the product level.  If `!important` is used in a component, a comment *must* be left in code to explain why it was necessary.
 * CSS expressions and behaviours *should not* be used, except to polyfill essential features for older browsers (e.g. boxsizing.htc for `box-sizing: border-box`)
 * Lengths *should* be expressed in pixel or percentage units, not ems or rems, with the exception of `line-height` which also accepts unitless values. A comment *should* be left in code when modern (`vh`, `vw`…) or relative units (`em`…) are used to document their purpose.
 
-##No @extends for foreign selectors
+## No @extends for foreign selectors
 
 The `@extends` command creates unpredictable cascades and unreliable results when used to extend placeholders defined in other modules, because the load order is unpredictable.  It *must not* be used in that way unless a dependent module can only be consumed via `@extends` for historical reasons.
 
 Extending a placeholder defined within the same module is permitted.
 
-##Sass variables
+## Sass variables
 
 * If a variable could potentially be used as a configurable option in products consuming the module, the variable *must* be defined with `!default` and added to the module's documentation
 * Variables that are internal to a module and which should not be used or set outside of it *should* be defined without !default.  Since Sass has no private scope, these underscore variables are not protected from overwriting so we use convention to distinguish them from public variables (see 'Privacy' below)
@@ -213,14 +213,14 @@ Extending a placeholder defined within the same module is permitted.
 * Variables intended for use externally by consuming products and modules *should* be defined by their purpose, rather than their value: e.g. `$o-colors-skyline-bg` rather than `$o-colors-beige`
 
 
-##Privacy and imports
+## Privacy and imports
 
 Any object (e.g. class, mixin, function, variable) that is intended for public use (i.e. may be referenced by code outside of its own module) *must* be documented in the module's README.  All other objects *must* be prefixed with an underscore character, and *must not* be documented in the README (they *may* be documented in code comments).
 
 If a module contains SCSS files other than the main file listed in bower.json, the file names of those files must be prefixed with an underscore, and all such files *must* be imported before any other Sass code.  All import statements *should* be in the module's main file.
 
 
-##Responsiveness
+## Responsiveness
 
 Modules are responsible for providing responsive behaviours where appropriate, but take care not to build in responsive behaviour that may not be desired by the product.
 
@@ -229,7 +229,7 @@ Modules are responsible for providing responsive behaviours where appropriate, b
 * When there is no media query support in the user agent (in the case of modules that use media queries) or the module's responsive mixins have not been used, the module *must* render in its most **compact** visual form.
 
 
-##Subresources
+## Subresources
 
 When styles refer to external resources such as fonts and images from an Origami module, the module *must* use `o-assets` to declare paths to these resources in a robust, build-agnostic fashion. Please see [the module's repository](https://github.com/financial-times/o-assets) for documentation and the rationale behind enforcing this approach.
 
@@ -237,7 +237,7 @@ Where external resources are not within Origami modules, a [protocol-relative UR
 
 
 
-##"Silent" styles
+## "Silent" styles
 
 Silent styles means SCSS code that compiles to an empty string, but provides mixins or variables that can be included or used by a dependent module.  Some modules can support silent styles easily, while others rely on class names to link elements to behaviour defined in JavaScript.
 
@@ -281,9 +281,9 @@ Modules that make use of styles defined in other modules that support silent mod
 Finally, in documentation, modules *must* provide information about both silent and non-silent methods, where supported, and must put the default first (i.e. if silent mode is by default **on**, the module must document the silent mode integration first).
 
 
-##Code organisation and formatting
+## Code organisation and formatting
 
-###Layout
+### Layout
 
 When listing multiple comma-separated selectors, each one *must* be placed on a new line.  Each property *must* be on a new line and indented (type of indent, tabs or spaces, is not standardised: developers *must* respect whatever indent type is already in use when editing existing modules)
 
@@ -295,14 +295,14 @@ When listing multiple comma-separated selectors, each one *must* be placed on a 
 	}
 
 
-###Files and folders
+### Files and folders
 
 Sass variables, mixins and functions *should* be in their own files, separate from the code that uses them.
 
 
-###Comments and documentation using SassDoc
+### Comments and documentation using SassDoc
 
-####SassDoc
+#### SassDoc
 
 <aside>
 <h4>What is SassDoc?</h4>
@@ -314,7 +314,7 @@ Sass variables, mixins and functions *should* be in their own files, separate fr
 * Inspiration for SassDoc documentation: [o-fonts module's src/scss folder](https://github.com/Financial-Times/o-fonts/tree/master/src/scss)
 
 
-####Comments
+#### Comments
 
 Before adding comments, consider whether the code can be made more expressive in order to remove the need for a comment. If the code is as expressive as it can reasonably be, but the intent is still not clear, then comments should be used to supplement the code.
 


### PR DESCRIPTION
- fix a typo
- fix a recently introduced bug with parsing markdown, where headings without a space between the text and the hash are not parsed at all.