### PR TITLE
Add new starter guide documentation 1st draft

### DIFF
--- a/new-starter-guide/2016-03-15-new-starter-to-origami.md
+++ b/new-starter-guide/2016-03-15-new-starter-to-origami.md
@@ -13,7 +13,7 @@ The checklist assumes that you have done the following:
 
 IT Services should have enabled admin privileges when they have set up your machine but you should [request admin access to your FT laptop via Salesforce](https://financialtimes.my.salesforce.com/home/home.jsp) to ensure it does not get revoked.
 
-If you do not have admin privileges then email `itservicedesk@ft.com`. Include your desk number (which is usually on the left of the desk) and the machine number with the email. You also will need to say why you need admin privileges, or alternatively copy the template below and edit accordingly.
+If you do not have admin privileges then email `itservicedesk@ft.com`. Include your desk number (which is usually a label on the front of your desk) and the machine number with the email. You also will need to say why you need admin privileges, or alternatively copy the template below and edit accordingly.
 
 ```
 Dear IT Service Desk,

--- a/new-starter-guide/2016-03-15-new-starter-to-origami.md
+++ b/new-starter-guide/2016-03-15-new-starter-to-origami.md
@@ -1,0 +1,149 @@
+# New starter guide
+
+Welcome to Origami!
+
+## Checklist of things to do
+
+The checklist assumes that you have done the following:
+
+1. Visit IT Service Desk to get your computer account up and running.
+2. Logged on your own work machine and email account.
+
+### Admin privileges on your machine
+
+IT Services should have enabled admin privileges when they have set up your machine but you should [request admin access to your FT laptop via Salesforce](https://financialtimes.my.salesforce.com/home/home.jsp) to ensure it does not get revoked.
+
+If you do not have admin privileges then email `itservicedesk@ft.com`. Include your desk number (which is usually on the left of the desk) and the machine number with the email. You also will need to say why you need admin privileges, or alternatively copy the template below and edit accordingly.
+
+```
+Dear IT Service Desk,
+
+I am a new starter within the Origami team, as a <your job title>. I would like to have admin privileges on <machine number> which is at <desk number>.
+
+The reasons for needing access to admin privileges is so that I can install software such as node.js, <your preferred text editor>, <add more if you like> and etc.
+
+I look forward to hearing back from you on this matter.
+
+Regards
+
+<your name>
+```
+
+This should expedite your request for admin privileges on your machine.
+
+
+### Slack
+
+1. Install Slack (This can be done without admin privileges).
+
+  > To install certain apps without admin privileges, you can access the Self Service app facility by finding it on your machine via Spotlight (under the assumption it's a Mac) Log in with your network details, and do a search for the Slack app and install. This is the same with browsers like Google Chrome or Mozilla Firefox.
+
+2. The Slack domain for FT is `financial-times`. Log into the domain with your FT email address.
+
+3. Join the `#ft-origami` channel and ask for invites to the internal channels from the Origami team.
+
+
+### Code repositories
+
+1. The public repositories are found at [GitHub/Financial-Times](https://github.com/Financial-Times) on GitHub. The private ones are found at [BitBucket](http://git.svc.ft.com/). The Origami repositories should be public if at all possible.
+
+2. Ask the Origami team for access to the following:
+
+  - To be added to the GitHub organisation Financial-Times
+  - To be added to the `origami-core` & `origami-colloborators` on the GitHub organisation's teams.
+  - Granted admin access to BitBucket.
+
+
+3. If you are using SSH, then don't forget to [generate new keys](https://help.github.com/articles/generating-an-ssh-key/), and add to your GitHub account if you haven't done so already.
+
+### LastPass
+
+Please do not just sign up on LastPass.com for a free account. You need to invited to the FT Enterprise LastPass account. To do this, ask `itservicedesk@ft.com` for your LastPass account to be enabled and, once this has been done, ask in the internal Origami channel on Slack to be added to the Labs team shared LastPass folder as an administrator.
+
+### Other tools
+
+Ask the Origami team to be added to:
+
+  - [Sentry](https://app.getsentry.com/auth/login/financial-times/)
+  - [Pingdom](https://www.pingdom.com/) (_optional_)
+  - [Heroku](https://www.heroku.com/)
+
+    - You will need to set up a Heroku account with your FT.com email address (Please enable <abbr title="Two Factor Authentication">2FA</abbr>).
+
+
+### Two Factor Authentication
+
+You will be asked to add <abbr title="Two Factor Authentication">2FA</abbr> for the following:
+
+- Work email
+- Heroku
+- LastPass
+
+It is a good idea to add an app on your phone for <abbr title="Two Factor Authentication">2FA</abbr> or configure it to send SMS messages with codes. There are options for apps like [Authy](https://www.authy.com/) ([App Store](https://itunes.apple.com/gb/app/authy/id494168017) / [Google Play](https://play.google.com/store/apps/details?id=com.authy.authy)) or Google Authenticator. ([App Store](https://itunes.apple.com/gb/app/google-authenticator/id388497605) / [Google Play](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2))
+
+### FT.com
+
+Check your email to see if you’ve already been registered for the free subscription to the [ft.com](https://www.ft.com/). If not, sign-up for an account on ft.com then ask `corporate.support@ft.com` to upgrade it to a free subscription.
+
+
+## Development tools
+
+### Environment setup
+
+Before you start installing anything, it is a good idea to do this (with admin privileges) to ensure that <abbr title="Node Package Manager">npm</abbr> is given permissions to install globally on your machine.
+
+```
+chown -R $USER /usr/local
+```
+
+Almost all Origami applications rely on the following tools to be installed globally on development machines. Please ensure both of these are installed successfully onto your development environment first.
+
+#### Install the following:
+
+- [Node.js](https://nodejs.org/)
+
+  - We recommend installing a [Node Version Manager](https://github.com/creationix/nvm) to manage different local node versions.
+
+- [Git](https://git-scm.com/)
+- [Heroku Toolbelt](https://toolbelt.heroku.com/)
+- [Bower](http://bower.io/)
+- [Ruby](http://www.ruby-lang.org/)
+
+  - We recommend installing a Ruby Version Manager to manage different ruby versions. There are two choices here. You can go either [Ruby Version Manager](https://rvm.io/) or [Rbenv](https://github.com/rbenv/rbenv).
+
+  - This is for the Ruby SCSS-Lint gem which is a part of <abbr title="Origami Build Tools">OBT</abbr>.
+
+#### Work with our ecosystem of components
+
+You will need to point Bower at the Origami registry. Running the following in a <abbr title="Command Line Interface">CLI</abbr> will do this for you.
+
+```
+[ -e ~/.bowerrc ] || echo '{ "registry": { "search": [ "http://registry.origami.ft.com", "https://bower.herokuapp.com" ] } }' > ~/.bowerrc
+```
+
+You can join all the Origami applications on Heroku by checking out this [shared Google Sheets](https://docs.google.com/a/ft.com/spreadsheets/d/1xk1tyn60ZCmLk1I39Dot-08c9pBJeeX3g9MDENDqjKk/edit?usp=drive_web).
+
+
+#### Issues with installing/getting access
+
+If you experience any problems, then please take a look at Next's [troubleshooting guide](http://financial-times.github.io/next/docs/developer-guide/troubleshooting/). If your problem is not included in the troubleshooting list and you manage to solve it, then please add it to the list.
+
+### Peer review and pull requests
+
+1. For more significant changes always ask for a peer review by posting a link on the relevant channel on slack or cc-ing one or more developers in GitHub.
+
+2. **If no-one reviews your code after a while**
+
+  - Go and ask somebody directly to do so.
+
+  - Stand next to them tutting and checking your watch if necessary.
+
+  - Review it yourself - the time spent waiting will have given you fresh eyes. If you feel confident everything’s OK go ahead and merge.
+
+3. It’s more important to verify your code works in the wild after deploying than it is to get the code approved by somebody before deploying.
+
+  - A thumbs up does not mean your code actually works so if releasing a change to an app keep an eye on it and check Sentry (The changes take about 10 minutes to show up due to Heroku preboot).
+
+  - Take all the above with a pinch of salt and trust your judgement.
+
+4. Our test coverage varies from one app to another but in general tests are a valuable thing. If the repo you’re working on is already well covered by tests add some to cover your changes too. If its test coverage is poor/non-existent don’t let that stop you from making a start by adding some to cover your new code.

--- a/new-starter-guide/2016-03-15-new-starter-to-origami.md
+++ b/new-starter-guide/2016-03-15-new-starter-to-origami.md
@@ -35,10 +35,9 @@ This should expedite your request for admin privileges on your machine.
 ### Slack
 
 1. Install Slack (This can be done without admin privileges).
-
   > To install certain apps without admin privileges, you can access the Self Service app facility by finding it on your machine via Spotlight (under the assumption it's a Mac) Log in with your network details, and do a search for the Slack app and install. This is the same with browsers like Google Chrome or Mozilla Firefox.
 
-2. The Slack domain for FT is `financial-times`. Log into the domain with your FT email address.
+2. The Slack domain for FT is `financialtimes`. Log into the domain with your FT email address.
 
 3. Join the `#ft-origami` channel and ask for invites to the internal channels from the Origami team.
 
@@ -48,11 +47,9 @@ This should expedite your request for admin privileges on your machine.
 1. The public repositories are found at [GitHub/Financial-Times](https://github.com/Financial-Times) on GitHub. The private ones are found at [BitBucket](http://git.svc.ft.com/). The Origami repositories should be public if at all possible.
 
 2. Ask the Origami team for access to the following:
-
   - To be added to the GitHub organisation Financial-Times
   - To be added to the `origami-core` & `origami-colloborators` on the GitHub organisation's teams.
   - Granted admin access to BitBucket.
-
 
 3. If you are using SSH, then don't forget to [generate new keys](https://help.github.com/articles/generating-an-ssh-key/), and add to your GitHub account if you haven't done so already.
 
@@ -64,12 +61,10 @@ Please do not just sign up on LastPass.com for a free account. You need to invit
 
 Ask the Origami team to be added to:
 
-  - [Sentry](https://app.getsentry.com/auth/login/financial-times/)
-  - [Pingdom](https://www.pingdom.com/) (_optional_)
-  - [Heroku](https://www.heroku.com/)
-
-    - You will need to set up a Heroku account with your FT.com email address (Please enable <abbr title="Two Factor Authentication">2FA</abbr>).
-
+- [Sentry](https://app.getsentry.com/auth/login/financial-times/)
+- [Pingdom](https://www.pingdom.com/) (_optional_)
+- [Heroku](https://www.heroku.com/)
+  - You will need to set up a Heroku account with your FT.com email address (Please enable <abbr title="Two Factor Authentication">2FA</abbr>).
 
 ### Two Factor Authentication
 
@@ -84,7 +79,6 @@ It is a good idea to add an app on your phone for <abbr title="Two Factor Authen
 ### FT.com
 
 Check your email to see if you’ve already been registered for the free subscription to the [ft.com](https://www.ft.com/). If not, sign-up for an account on ft.com then ask `corporate.support@ft.com` to upgrade it to a free subscription.
-
 
 ## Development tools
 
@@ -101,16 +95,12 @@ Almost all Origami applications rely on the following tools to be installed glob
 #### Install the following:
 
 - [Node.js](https://nodejs.org/)
-
   - We recommend installing a [Node Version Manager](https://github.com/creationix/nvm) to manage different local node versions.
-
 - [Git](https://git-scm.com/)
 - [Heroku Toolbelt](https://toolbelt.heroku.com/)
 - [Bower](http://bower.io/)
 - [Ruby](http://www.ruby-lang.org/)
-
   - We recommend installing a Ruby Version Manager to manage different ruby versions. There are two choices here. You can go either [Ruby Version Manager](https://rvm.io/) or [Rbenv](https://github.com/rbenv/rbenv).
-
   - This is for the Ruby SCSS-Lint gem which is a part of <abbr title="Origami Build Tools">OBT</abbr>.
 
 #### Work with our ecosystem of components
@@ -133,17 +123,12 @@ If you experience any problems, then please take a look at Next's [troubleshooti
 1. For more significant changes always ask for a peer review by posting a link on the relevant channel on slack or cc-ing one or more developers in GitHub.
 
 2. **If no-one reviews your code after a while**
-
   - Go and ask somebody directly to do so.
-
   - Stand next to them tutting and checking your watch if necessary.
-
   - Review it yourself - the time spent waiting will have given you fresh eyes. If you feel confident everything’s OK go ahead and merge.
 
 3. It’s more important to verify your code works in the wild after deploying than it is to get the code approved by somebody before deploying.
-
   - A thumbs up does not mean your code actually works so if releasing a change to an app keep an eye on it and check Sentry (The changes take about 10 minutes to show up due to Heroku preboot).
-
   - Take all the above with a pinch of salt and trust your judgement.
 
 4. Our test coverage varies from one app to another but in general tests are a valuable thing. If the repo you’re working on is already well covered by tests add some to cover your changes too. If its test coverage is poor/non-existent don’t let that stop you from making a start by adding some to cover your new code.

--- a/new-starter-guide/new-starter-to-origami.md
+++ b/new-starter-guide/new-starter-to-origami.md
@@ -6,12 +6,12 @@ Welcome to Origami!
 
 The checklist assumes that you have done the following:
 
-1. Visit IT Service Desk to get your computer account up and running.
+1. Visited IT Service Desk (ITSD) to get your computer account up and running.
 2. Logged on your own work machine and email account.
 
 ### Admin privileges on your machine
 
-IT Services should have enabled admin privileges when they have set up your machine but you should [request admin access to your FT laptop via Salesforce](https://financialtimes.my.salesforce.com/home/home.jsp) to ensure it does not get revoked.
+<abbr title="IT Services Desk">ITSD</abbr> should have enabled admin privileges when they have set up your machine but you should [request admin access to your FT laptop via Salesforce](https://financialtimes.my.salesforce.com/home/home.jsp) to ensure it does not get revoked.
 
 If you do not have admin privileges then email `itservicedesk@ft.com`. Include your desk number (which is usually a label on the front of your desk) and the machine number with the email. You also will need to say why you need admin privileges, or alternatively copy the template below and edit accordingly.
 
@@ -24,34 +24,34 @@ The reasons for needing access to admin privileges is so that I can install soft
 
 I look forward to hearing back from you on this matter.
 
-Regards
+Thanks
 
 <your name>
 ```
 
 This should expedite your request for admin privileges on your machine.
 
-
 ### Slack
 
 1. Install Slack (This can be done without admin privileges).
-  > To install certain apps without admin privileges, you can access the Self Service app facility by finding it on your machine via Spotlight (under the assumption it's a Mac) Log in with your network details, and do a search for the Slack app and install. This is the same with browsers like Google Chrome or Mozilla Firefox.
+  > To install certain apps without admin privileges, you can access the Self Service app facility by finding it on your machine via Spotlight (under the assumption it's a Mac) Log in with your network details, and do a search for the Slack app and install. This is the same with browsers like Google Chrome or Mozilla Firefox. You will need to be connected to the FT LAN for this to work.
 
 2. The Slack domain for FT is `financialtimes`. Log into the domain with your FT email address.
 
 3. Join the `#ft-origami` channel and ask for invites to the internal channels from the Origami team.
 
-
 ### Code repositories
 
-1. The public repositories are found at [GitHub/Financial-Times](https://github.com/Financial-Times) on GitHub. The private ones are found at [BitBucket](http://git.svc.ft.com/). The Origami repositories should be public if at all possible. We also are looking into moving all private repositories onto GitHub.
+1. The public repositories are found at [GitHub/Financial-Times](https://github.com/Financial-Times) on GitHub. The private ones are found at [BitBucket](http://git.svc.ft.com/). Origami repositories should be public if at all possible. We also are looking into moving all private repositories onto GitHub.
 
 2. Ask the Origami team for access to the following:
   - To be added to the GitHub organisation Financial-Times
   - To be added to the `origami-core` & `origami-colloborators` on the GitHub organisation's teams.
   - Granted admin access to BitBucket.
 
-3. If you are using SSH, then don't forget to [generate new keys](https://help.github.com/articles/generating-an-ssh-key/), and add to your GitHub account if you haven't done so already.
+3. If you haven't done so already, please set up [2-factor authentication](https://help.github.com/articles/about-two-factor-authentication/) for GitHub.
+
+4. If you are using SSH, then don't forget to [generate new keys](https://help.github.com/articles/generating-an-ssh-key/), and add to your GitHub account if you haven't done so already.
 
 ### LastPass
 
@@ -71,6 +71,7 @@ Ask the Origami team to be added to:
 You will be asked to add <abbr title="Two Factor Authentication">2FA</abbr> for the following:
 
 - Work email
+- GitHub
 - Heroku
 - LastPass
 
@@ -113,11 +114,20 @@ You will need to point Bower at the Origami registry. Running the following in a
 
 You can join all the Origami applications on Heroku by checking out this [shared Google Sheets](https://docs.google.com/a/ft.com/spreadsheets/d/1xk1tyn60ZCmLk1I39Dot-08c9pBJeeX3g9MDENDqjKk/edit?usp=drive_web). You will need one other person from the Origami team to add you.
 
-
 #### Issues with installing/getting access
 
 If you experience any problems, then please take a look at Next's [troubleshooting guide](http://financial-times.github.io/next/docs/developer-guide/troubleshooting/). If your problem is not included in the troubleshooting list and you manage to solve it, then please add it to the list.
 
 ### Peer review and pull requests
 
-With all the work that you would produce for Origami and when you reach the stage of doing a pull request, ask someone within the team for a review of your work. If it gets the thumbs up from the reviewer then you're free to merge it into the master branch of the repository. It also depends on the size of the work that was produced, if it's quite substantial then it would require more people to look over the work before giving the all clear to merge.
+All code in Origami is written by one person and peer reviewed by one or more people using git branches and merging.
+
+#### Here's how it works
+
+1. Branch off of master: `git branch my-great-feature`
+2. [some coding / committing happens in the `my-great-feature branch`]
+3. Push those changes to GitHub / Stash: `git push origin my-great-feature-branch`
+4. Repeat 2 and 3 as much as you like
+5. When you're ready, open a pull request. Tag people you'd like to review the request.
+6. Respond to review comments
+7. Either a reviewer will merge your request, or they will give you a thumbs-up for you to merge.

--- a/new-starter-guide/new-starter-to-origami.md
+++ b/new-starter-guide/new-starter-to-origami.md
@@ -11,16 +11,18 @@ The checklist assumes that you have done the following:
 
 ### Admin privileges on your machine
 
-<abbr title="IT Services Desk">ITSD</abbr> should have enabled admin privileges when they have set up your machine but you should [request admin access to your FT laptop via Salesforce](https://financialtimes.my.salesforce.com/home/home.jsp) to ensure it does not get revoked.
+<abbr title="IT Services Desk">ITSD</abbr> should have done admin privileges for you and your machine when they did the setup. If not, then you should [request admin access to your FT laptop via Salesforce](https://financialtimes.my.salesforce.com/home/home.jsp) to ensure it does not get revoked.
 
-If you do not have admin privileges then email `itservicedesk@ft.com`. Include your desk number (which is usually a label on the front of your desk) and the machine number with the email. You also will need to say why you need admin privileges, or alternatively copy the template below and edit accordingly.
+If you do not have admin privileges then email `itservicedesk@ft.com`.
+
+Include your desk number (which is usually a label on your desk) and the machine number with the email. You also will need to say why you need admin privileges, or copy the template below and edit to suit the situation.
 
 ```
 Dear IT Service Desk,
 
 I am a new starter within the Origami team, as a <your job title>. I would like to have admin privileges on <machine number> which is at <desk number>.
 
-The reasons for needing access to admin privileges is so that I can install software such as node.js, <your preferred text editor>, <add more if you like> and etc.
+I need to be able to install software like node.js, <your preferred text editor> & <add more if you like>.
 
 I look forward to hearing back from you on this matter.
 
@@ -29,46 +31,46 @@ Thanks
 <your name>
 ```
 
-This should expedite your request for admin privileges on your machine.
+This should hurry your request for admin privileges on your machine.
 
 ### Slack
 
-1. Install Slack (This can be done without admin privileges).
-  > To install certain apps without admin privileges, you can access the Self Service app facility by finding it on your machine via Spotlight (under the assumption it's a Mac) Log in with your network details, and do a search for the Slack app and install. This is the same with browsers like Google Chrome or Mozilla Firefox. You will need to be connected to the FT LAN for this to work.
+1. Install Slack (You can do this without admin privileges).
+  > To install software without having admin privileges. You can access the Self Service application by finding it on your machine. Log in with your network details, and do a search for the Slack app and install. This is the same with browsers like Google Chrome or Mozilla Firefox. You will need to be on the FT LAN for this to work.
 
 2. The Slack domain for FT is `financialtimes`. Log into the domain with your FT email address.
 
-3. Join the `#ft-origami` channel and ask for invites to the internal channels from the Origami team.
+3. Join the `#ft-origami` channel, then ask the team to add you to the internal channels.
 
 ### Code repositories
 
-1. The public repositories are found at [GitHub/Financial-Times](https://github.com/Financial-Times) on GitHub. The private ones are found at [BitBucket](http://git.svc.ft.com/). Origami repositories should be public if at all possible. We also are looking into moving all private repositories onto GitHub.
+1. The public repositories are at [GitHub/Financial-Times](https://github.com/Financial-Times) on GitHub. The private ones are at [BitBucket](http://git.svc.ft.com/). Origami repositories should be public if at all possible. We also are looking into moving all private repositories onto GitHub.
 
 2. Ask the Origami team for access to the following:
-  - To be added to the GitHub organisation Financial-Times
-  - To be added to the `origami-core` & `origami-colloborators` on the GitHub organisation's teams.
+  - The GitHub organisation Financial-Times
+  - The `origami-core` & `origami-colloborators` on the GitHub organisation's teams.
   - Granted admin access to BitBucket.
 
 3. If you haven't done so already, please set up [2-factor authentication](https://help.github.com/articles/about-two-factor-authentication/) for GitHub.
 
-4. If you are using SSH, then don't forget to [generate new keys](https://help.github.com/articles/generating-an-ssh-key/), and add to your GitHub account if you haven't done so already.
+4. If you are using SSH, then don't forget to [generate new keys](https://help.github.com/articles/generating-an-ssh-key/), and add to your GitHub account.
 
 ### LastPass
 
-Please do not just sign up on LastPass.com for a free account. You need to invited to the FT Enterprise LastPass account. To do this, ask `itservicedesk@ft.com` for your LastPass account to be enabled and, once this has been done, ask in the internal Origami channel on Slack to be added to the Origami team shared LastPass folder as an administrator.
+Please do not just sign up on LastPass.com for a free account. You need to invited to the FT Enterprise LastPass account. Ask `itservicedesk@ft.com` to enable your LastPass account. Then ask a member of the team to add you to the Shared-origami folder as an administrator.
 
 ### Other tools
 
-Ask the Origami team to be added to:
+Ask the Origami team for access to:
 
 - [Sentry](https://app.getsentry.com/auth/login/financial-times/)
 - [Pingdom](https://www.pingdom.com/) (_optional_)
 - [Heroku](https://www.heroku.com/)
-  - You will need to set up a Heroku account with your FT.com email address (Please enable <abbr title="Two Factor Authentication">2FA</abbr>).
+  - Set up a Heroku account with your FT.com email address (Please enable <abbr title="Two Factor Authentication">2FA</abbr>).
 
 ### Two Factor Authentication
 
-You will be asked to add <abbr title="Two Factor Authentication">2FA</abbr> for the following:
+You will need to add <abbr title="Two Factor Authentication">2FA</abbr> for the following:
 
 - Work email
 - GitHub
@@ -79,23 +81,23 @@ It is a good idea to add an app on your phone for <abbr title="Two Factor Authen
 
 ### FT.com
 
-Check your email to see if you’ve already been registered for the free subscription to the [ft.com](https://www.ft.com/). If not, sign-up for an account on ft.com then ask `corporate.support@ft.com` to upgrade it to a free subscription.
+Check your email to see if you’ve registered for the free subscription to [ft.com](https://www.ft.com/). If not, sign-up for an account on ft.com and ask `corporate.support@ft.com` to upgrade it.
 
 ## Development tools
 
 ### Environment setup
 
-Before you start installing anything, it is a good idea to do this (with admin privileges) to ensure that <abbr title="Node Package Manager">npm</abbr> is given permissions to install globally on your machine.
+Before anything gets installed on your machine. It is a good idea to ensure that <abbr title="Node Package Manager">npm</abbr> has permissions to install globally.
 
 ```
 chown -R $USER /usr/local
 ```
 
-Almost all Origami applications rely on the following tools to be installed globally on development machines. Please ensure both of these are installed successfully onto your development environment first.
+Almost all Origami applications rely on the following tools to be installed globally on development machines. Please ensure that you install the software in your development environment first.
 
 #### Install the following:
 
-- [Node.js](https://nodejs.org/) - The components are widely supported in Node v4, not with Node v5.
+- [Node.js](https://nodejs.org/) - The components are supported in Node v4 or Node v5.
   - We recommend installing a [Node Version Manager](https://github.com/creationix/nvm) to manage different local node versions.
 - [Git](https://git-scm.com/)
 - [Heroku Toolbelt](https://toolbelt.heroku.com/)
@@ -116,11 +118,11 @@ You can join all the Origami applications on Heroku by checking out this [shared
 
 #### Issues with installing/getting access
 
-If you experience any problems, then please take a look at Next's [troubleshooting guide](http://financial-times.github.io/next/docs/developer-guide/troubleshooting/). If your problem is not included in the troubleshooting list and you manage to solve it, then please add it to the list.
+If you experience any problems, then please take a look at Next's troubleshooting guide. If your problem is not included in the [troubleshooting guide](http://financial-times.github.io/next/docs/developer-guide/troubleshooting/) and you manage to solve it, then add it to the list.
 
 ### Peer review and pull requests
 
-All code in Origami is written by one person and peer reviewed by one or more people using git branches and merging.
+One person writes all the code in a Origami module. The code will be peer reviewed by one or more people using git branches and merging.
 
 #### Here's how it works
 

--- a/new-starter-guide/new-starter-to-origami.md
+++ b/new-starter-guide/new-starter-to-origami.md
@@ -122,7 +122,7 @@ If you experience any problems, then please take a look at Next's troubleshootin
 
 ### Peer review and pull requests
 
-One person writes all the code in a Origami module. The code will be peer reviewed by one or more people using git branches and merging.
+All contributors to Origami must use Pull Requests. These should be peer-reviewed by one or more people before merging.
 
 #### Here's how it works
 

--- a/new-starter-guide/new-starter-to-origami.md
+++ b/new-starter-guide/new-starter-to-origami.md
@@ -44,7 +44,7 @@ This should expedite your request for admin privileges on your machine.
 
 ### Code repositories
 
-1. The public repositories are found at [GitHub/Financial-Times](https://github.com/Financial-Times) on GitHub. The private ones are found at [BitBucket](http://git.svc.ft.com/). The Origami repositories should be public if at all possible.
+1. The public repositories are found at [GitHub/Financial-Times](https://github.com/Financial-Times) on GitHub. The private ones are found at [BitBucket](http://git.svc.ft.com/). The Origami repositories should be public if at all possible. We also are looking into moving all private repositories onto GitHub.
 
 2. Ask the Origami team for access to the following:
   - To be added to the GitHub organisation Financial-Times
@@ -55,7 +55,7 @@ This should expedite your request for admin privileges on your machine.
 
 ### LastPass
 
-Please do not just sign up on LastPass.com for a free account. You need to invited to the FT Enterprise LastPass account. To do this, ask `itservicedesk@ft.com` for your LastPass account to be enabled and, once this has been done, ask in the internal Origami channel on Slack to be added to the Labs team shared LastPass folder as an administrator.
+Please do not just sign up on LastPass.com for a free account. You need to invited to the FT Enterprise LastPass account. To do this, ask `itservicedesk@ft.com` for your LastPass account to be enabled and, once this has been done, ask in the internal Origami channel on Slack to be added to the Origami team shared LastPass folder as an administrator.
 
 ### Other tools
 
@@ -111,7 +111,7 @@ You will need to point Bower at the Origami registry. Running the following in a
 [ -e ~/.bowerrc ] || echo '{ "registry": { "search": [ "http://registry.origami.ft.com", "https://bower.herokuapp.com" ] } }' > ~/.bowerrc
 ```
 
-You can join all the Origami applications on Heroku by checking out this [shared Google Sheets](https://docs.google.com/a/ft.com/spreadsheets/d/1xk1tyn60ZCmLk1I39Dot-08c9pBJeeX3g9MDENDqjKk/edit?usp=drive_web).
+You can join all the Origami applications on Heroku by checking out this [shared Google Sheets](https://docs.google.com/a/ft.com/spreadsheets/d/1xk1tyn60ZCmLk1I39Dot-08c9pBJeeX3g9MDENDqjKk/edit?usp=drive_web). You will need one other person from the Origami team to add you.
 
 
 #### Issues with installing/getting access
@@ -120,15 +120,4 @@ If you experience any problems, then please take a look at Next's [troubleshooti
 
 ### Peer review and pull requests
 
-1. For more significant changes always ask for a peer review by posting a link on the relevant channel on slack or cc-ing one or more developers in GitHub.
-
-2. **If no-one reviews your code after a while**
-  - Go and ask somebody directly to do so.
-  - Stand next to them tutting and checking your watch if necessary.
-  - Review it yourself - the time spent waiting will have given you fresh eyes. If you feel confident everything’s OK go ahead and merge.
-
-3. It’s more important to verify your code works in the wild after deploying than it is to get the code approved by somebody before deploying.
-  - A thumbs up does not mean your code actually works so if releasing a change to an app keep an eye on it and check Sentry (The changes take about 10 minutes to show up due to Heroku preboot).
-  - Take all the above with a pinch of salt and trust your judgement.
-
-4. Our test coverage varies from one app to another but in general tests are a valuable thing. If the repo you’re working on is already well covered by tests add some to cover your changes too. If its test coverage is poor/non-existent don’t let that stop you from making a start by adding some to cover your new code.
+With all the work that you would produce for Origami and when you reach the stage of doing a pull request, ask someone within the team for a review of your work. If it gets the thumbs up from the reviewer then you're free to merge it into the master branch of the repository. It also depends on the size of the work that was produced, if it's quite substantial then it would require more people to look over the work before giving the all clear to merge.

--- a/new-starter-guide/new-starter-to-origami.md
+++ b/new-starter-guide/new-starter-to-origami.md
@@ -95,7 +95,7 @@ Almost all Origami applications rely on the following tools to be installed glob
 
 #### Install the following:
 
-- [Node.js](https://nodejs.org/)
+- [Node.js](https://nodejs.org/) - The components are widely supported in Node v4, not with Node v5.
   - We recommend installing a [Node Version Manager](https://github.com/creationix/nvm) to manage different local node versions.
 - [Git](https://git-scm.com/)
 - [Heroku Toolbelt](https://toolbelt.heroku.com/)


### PR DESCRIPTION
I've added a first draft of the new starter guide that's more specific to Origami.

This needs some reviewing from @Financial-Times/origami-core :+1:. This can be relocated in a better place in the documentation later when it has been ratified.