### PR TITLE
Update spec and dev guide titles and core vs enhanced docs for devs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,11 +21,9 @@
         </div>
         <nav class="o-header__primary__right o-hierarchical-nav o-header__nav--primary-theme" data-o-component="o-hierarchical-nav">
           <ul data-o-hierarchical-nav-level="1"><!--
-            --><li data-priority="1" aria-selected="true"><a href="http://origami.ft.com">Spec</a></li><!--
-            --><li data-priority="1"><a href="http://registry.origami.ft.com">Registry</a></li><!--
-            --><li data-priority="1"><a href="http://styleguide.ft.com">Style Guide</a></li><!--
-            --><li data-more class="o-hierarchical-nav__parent" aria-hidden="true"><a><span class="o-hierarchical-nav__more--if-some">More <i class="o-hierarchical-nav__parent__down-arrow"></i></span><span class="o-hierarchical-nav__more--if-all">Menu <i class="o-hierarchical-nav__parent__down-arrow"></i></span></a></li><!--
-          --></ul>
+	        --><li data-priority="1" aria-selected="true"><a href="http://origami.ft.com">Spec</a></li><!--
+	        --><li data-priority="1"><a href="http://registry.origami.ft.com">Registry</a></li><!--
+	      --></ul>
         </nav>
       </div>
       <div class="o-header__secondary o-header__nav--secondary-theme">

--- a/_includes/home-banner.html
+++ b/_includes/home-banner.html
@@ -11,7 +11,7 @@
 				</p>
 				<div class="hero__actions">
 					<a href="{{ site.baseurl }}/docs/developer-guide/" class="o-buttons o-buttons--big o-buttons--inverse" title="Developer guide">
-						Start coding
+						Start using Origami
 					</a>
 				</div>
 			</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,8 +51,8 @@
 						{% endif %}
 					</li> -->
 					<li {% if page.title == 'Component spec' %} aria-expanded="true" aria-selected="true"{% endif %}>
-						<a href="{{ site.baseurl }}/docs/component-spec">Component spec</a>
-						{% if page.section == 'Component spec' %}
+						<a href="{{ site.baseurl }}/docs/component-specification">Component specification</a>
+						{% if page.section == 'Component specification' %}
 						<ul class="o-techdocs-nav o-techdocs-nav--sub">
 							<li{% if page.title == 'Modules' %} aria-selected="true"{% endif %}>
 								<a href="{{ site.baseurl }}/docs/component-spec/modules">Modules</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
 						</li>
 					{% endif %}
 					{% if page.site_section == 'about-origami' %}
-					<li {% if page.title == 'Home' %} aria-expanded="true" aria-selected="true"{% endif %}>
+					<!-- <li {% if page.title == 'Home' %} aria-expanded="true" aria-selected="true"{% endif %}>
 						<a href="{{ site.baseurl }}/">Overview</a>
 						{% if page.section == 'Overview' %}
 						<ul class="o-techdocs-nav o-techdocs-nav--sub">
@@ -49,7 +49,7 @@
 							</li>
 						</ul>
 						{% endif %}
-					</li>
+					</li> -->
 					<li {% if page.title == 'Component spec' %} aria-expanded="true" aria-selected="true"{% endif %}>
 						<a href="{{ site.baseurl }}/docs/component-spec">Component spec</a>
 						{% if page.section == 'Component spec' %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,8 +51,8 @@
 						{% endif %}
 					</li> -->
 					<li {% if page.title == 'Component spec' %} aria-expanded="true" aria-selected="true"{% endif %}>
-						<a href="{{ site.baseurl }}/docs/component-specification">Component specification</a>
-						{% if page.section == 'Component specification' %}
+						<a href="{{ site.baseurl }}/docs/component-spec">Component specification</a>
+						{% if page.section == 'Component spec' %}
 						<ul class="o-techdocs-nav o-techdocs-nav--sub">
 							<li{% if page.title == 'Modules' %} aria-selected="true"{% endif %}>
 								<a href="{{ site.baseurl }}/docs/component-spec/modules">Modules</a>

--- a/docs/component-spec/index.md
+++ b/docs/component-spec/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Component spec
+title: Component specification
 section: Component spec
 permalink: /docs/component-spec/
 site_section: about-origami

--- a/docs/component-spec/index.md
+++ b/docs/component-spec/index.md
@@ -6,7 +6,7 @@ permalink: /docs/component-spec/
 site_section: about-origami
 ---
 
-# Component specification
+# Building Origami components
 
 This section defines the requirements for Origami-conforming components and is a [normative specification](http://www.w3.org/TR/qaframe-spec/).  Non-normative (informative) sections are indicated explicitly or by inset and boxed asides.  The words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** have the meaning given to them in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt)
 

--- a/docs/component-spec/index.md
+++ b/docs/component-spec/index.md
@@ -6,7 +6,9 @@ permalink: /docs/component-spec/
 site_section: about-origami
 ---
 
-# Building Origami components
+# Origami component specification
+
+_To start using Origami components with your product, see the [using Origami in your products]({{site.baseurl}}/docs/developer-guide/) section._
 
 This section defines the requirements for Origami-conforming components and is a [normative specification](http://www.w3.org/TR/qaframe-spec/).  Non-normative (informative) sections are indicated explicitly or by inset and boxed asides.  The words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** have the meaning given to them in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt)
 

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -6,7 +6,7 @@ permalink: /docs/developer-guide/
 site_section: developer-guide
 ---
 
-# Developer guide
+# Building products with Origami
 
 When you're building a new web product, chances are you need a lot of stuff that's common across many FT sites.  Origami **modules** provide you with common functional components, behaviours, layouts and styles, while Origami **web services** provide dynamic data services and markup feeds.
 

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -6,7 +6,7 @@ permalink: /docs/developer-guide/
 site_section: developer-guide
 ---
 
-# Building products with Origami
+# Using Origami components
 
 When you're building a new web product, chances are you need a lot of stuff that's common across many FT sites.  Origami **modules** provide you with common functional components, behaviours, layouts and styles, while Origami **web services** provide dynamic data services and markup feeds.
 

--- a/docs/developer-guide/using-modules.md
+++ b/docs/developer-guide/using-modules.md
@@ -17,7 +17,7 @@ If you are not sure which strategy to use to build your CSS and JS, consult the 
 <table class="o-techdocs-table">
 <tr><th>Feature</th><th>Building manually</th><th>Using the build service</th></tr>
 <tr><td>Unopinionated about your server-side technology stack</td><td>No.  You will need Node.js (for package management and build automation) and Ruby (for Sass linting)</td><td>Yes, there is no requirement for any server-side code</td></tr>
-<tr><td>Can get set up quickly</td><td>No.  If you're not familiar with Node.js and don't have any pre-requisites installed, getting set up could take you a couple of hours</td><td>Yes, a few minutes at most</td></tr>
+<tr><td>Can get set up quickly</td><td>No. If you're not familiar with Node.js and don't have any pre-requisites installed, getting set up could take you a couple of hours</td><td>Yes, a few minutes at most</td></tr>
 <tr><td>Can add your own front-end code to the Origami bundle</td><td>Yes, trivially</td><td>Not easily.  You'd have to publish that code as a standalone repo</td></tr>
 <tr><td>Can use public open source JavaScript modules like jQuery</td><td>Yes</td><td>Yes, provided that they have a CommonJS interface</td></tr>
 <tr><td>Can develop without being online</td><td>Yes</td><td>No, you need to be online if your pages pull resources from the build service.</td></tr>

--- a/docs/syntax/html.md
+++ b/docs/syntax/html.md
@@ -68,7 +68,8 @@ Markup may contain elements that do not work without accompanying JavaScript.  T
 	<div class="o--if-js">Submit a new comment: ... </div>
 	<div class="o--if-no-js">To comment on this article, you need to upgrade your web browser.  <a href="...">Learn how to upgrade</a>.</div>
 
-With this method it is possible to trigger unwanted HTTP requests to be made should you include an image within the `o--if-no-js` element or use a CSS background image on the element ([Learn more](http://timkadlec.com/2012/04/media-query-asset-downloading-results/)). If you require an image to be added to the page for core experience only, you could use a `<noscript>` tag:
+Elements with the class `o--if-no-js` will trigger unnecessary HTTP requests if they are (or contain) `<img>` tags or have a background image URL set with CSS ([learn more](http://timkadlec.com/2012/04/media-query-asset-downloading-results/)).
+If you require an image to be added to a page for core experience only, you should use a `<noscript>` tag:
 
 	<script>
 		(function () {

--- a/docs/syntax/html.md
+++ b/docs/syntax/html.md
@@ -68,9 +68,22 @@ Markup may contain elements that do not work without accompanying JavaScript.  T
 	<div class="o--if-js">Submit a new comment: ... </div>
 	<div class="o--if-no-js">To comment on this article, you need to upgrade your web browser.  <a href="...">Learn how to upgrade</a>.</div>
 
-To avoid unnecessary HTTP requests, elements with the class `o--if-no-js` *must not* be (or contain) `<img>` tags, and *must not* have a background image URL set with CSS.  Descendent elements of the `o--if-no-js` element *may* have CSS image backgrounds ([Learn more](http://timkadlec.com/2012/04/media-query-asset-downloading-results/))
+With this method it is possible to trigger unwanted HTTP requests to be made should you include an image within the `o--if-no-js` element or use a CSS background image on the element ([Learn more](http://timkadlec.com/2012/04/media-query-asset-downloading-results/)). If you require an image to be added to the page for core experience only, you could use a `<noscript>` tag:
 
-* Learn more about [Core vs enhanced experience]({{site.baseurl}}/docs/developer-guide/using-modules/#core-vs-enhanced-experience)
+	<script>
+		(function () {
+			// Apply your cuts the mustard test to load the image for enhanced experience
+			if (!('querySelector' in document && 'localStorage' in window && 'addEventListener' in window) ) {
+				var img = new Image();
+				img.src = 'https://spoor-api.ft.com/px.gif?xxxxxx';
+			}
+		})();
+	</script>
+	<noscript data-o-component="o-tracking">
+		<img src="https://spoor-api.ft.com/px.gif?xxxxxx"/>
+	</noscript>
+
+Learn more about [Core vs enhanced experience]({{site.baseurl}}/docs/developer-guide/using-modules/#core-vs-enhanced-experience)
 
 ## WAI-ARIA
 


### PR DESCRIPTION
Fixes #444 

Here's a first go at changing the docs for the core vs enhanced example in the developer guide. I've also updated the homepage banner and titles for the developer guide and spec landing pages.