### PR TITLE
Add rule to make major release when adding new dep

### DIFF
--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -112,6 +112,7 @@ Origami modules are generally installed based on a semver range. To ensure new r
 * Deprecated functions and mixins should log a warning stating that they are now deprecated and offering an alternative when there is one. This warning *may* also be added to the readme
 * When updating a dependency to the latest minor release, make a minor release
 * When updating a dependency to the latest major release, in your bower.json, make sure the semver range includes the previous major release (_e.g. `>=1.2.3 <3`_). If not, a major release is necessary
+* When adding a new dependency, make a major release as it make break existing bundles
 * Make sure private Sass functions and mixins are prefixed with an underscore. If not, even if they weren’t intended for public use, they will need to follow the same deprecation process as public functions and mixins
 * All JavaScript components *must* have tests and they *must* pass
 * Run `obt verify` and `obt test` and make sure there are no errors

--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -112,7 +112,7 @@ Origami modules are generally installed based on a semver range. To ensure new r
 * Deprecated functions and mixins should log a warning stating that they are now deprecated and offering an alternative when there is one. This warning *may* also be added to the readme
 * When updating a dependency to the latest minor release, make a minor release
 * When updating a dependency to the latest major release, in your bower.json, make sure the semver range includes the previous major release (_e.g. `>=1.2.3 <3`_). If not, a major release is necessary
-* When adding a new dependency, make a major release as it make break existing bundles
+* When adding a new dependency, make a major release as it may break existing bundles
 * Make sure private Sass functions and mixins are prefixed with an underscore. If not, even if they weren’t intended for public use, they will need to follow the same deprecation process as public functions and mixins
 * All JavaScript components *must* have tests and they *must* pass
 * Run `obt verify` and `obt test` and make sure there are no errors


### PR DESCRIPTION
We broke bundles when adding o-ft-icons to o-buttons, and we must prevent this