### PR TITLE
Use non-silent header in example main.scss

### DIFF
--- a/docs/developer-guide/building-modules.md
+++ b/docs/developer-guide/building-modules.md
@@ -208,6 +208,9 @@ As an example (assuming you loaded these modules in your `bower.json`), create a
 	// Output icon helper classes
 	$o-ft-icons-is-silent: false;
 
+	// Output header classes
+	$o-header-is-silent: false;
+
 	// Import Origami components
 	@import 'o-grid/main';
 	@import 'o-fonts/main';


### PR DESCRIPTION
This fixes a small bug when following along the docs for the
first time. Without the silent flag the header does not render
correctly.