### PR TITLE
Add Pa11y

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+HOST = localhost:4000
+NPM_BIN = ./node_modules/.bin
+export PATH := $(NPM_BIN):$(PATH)
+
+# Install dependencies
+install:
+	@echo "Installing Pa11y..."
+	@npm install pa11y@^3
+	@echo "Installing GitHub Pages gem..."
+	@gem install github-pages
+
+# Build the site
+build:
+	@echo "Building site"
+	@exec jekyll build --drafts
+
+# Watch the site for changes, then build
+watch:
+	@echo "Watching and building site"
+	@exec jekyll build --watch
+
+# Serve the site locally
+serve:
+	@echo "Watching files and serving site on localhost:4000"
+	@exec jekyll serve --watch
+
+# List all of the URLs in a locally running site
+list-urls:
+	@curl -s http://$(HOST)/sitemap.xml | grep "<loc>" \
+		| sed -e 's/<loc>//g' \
+		| sed -e 's/<\/loc>//g' \
+		| sed -e "s/^\//http:\/\/$(HOST)\//g" \
+		| sort
+
+# Run pa11y against the site
+test:
+	@echo "Testing site"
+	@make list-urls | sed '/^$$/d' | { while read i; do pa11y --ignore "notice;warning" $$i || exit 1; done }
+# This is set up to fail on a page when it finds at least one accessibility error.
+# If it passes on a page, it will move onto the next until an error is found.

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,22 @@
-name: Origami
-highlighter: rouge
-relative_permalinks: false
-baseurl:
-exclude: [scss, node_modules, bower.json, Gruntfile.js, package.json, README.md]
-markdown: kramdown
+# Files to exclude from compilation
+exclude:
+- CNAME
+- Gruntfile.js
+- Makefile
+- node_modules
+- package.json
+- README.md
+
+# Jekyll plugins
 gems:
 - jekyll-redirect-from
+- jekyll-sitemap
+
+# Markdown settings
+highlighter: rouge # syntax
+markdown: kramdown # engine
+
+# Website settings
+baseurl: '' # This is empty on purpose
+name: Origami
+relative_permalinks: false

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+machine:
+  node:
+    version: 4
+  ruby:
+    version: 2.3.0
+dependencies:
+  pre:
+  - make install
+  cache_directories:
+    - "node_modules"
+test:
+  override:
+    - make serve:
+        background: true
+    - sleep 5
+    - make test


### PR DESCRIPTION
Closes #484.

Add `Makefile` which will do the following when prompted by the developer:

1. Install Pa11y and GitHub Pages gem.
2. Build, serve locally with Jekyll via GitHub Pages gem.
3. Run Pa11y tests locally and output Pa11y accessibility error results.

Add `circle.yml` which will replicate the above.

**Note:** origami.ft.com currently has some Pa11y errors which will cause CircleCI to fail the build. This will pass once all the accessibility errors have been fixed. I have raised an issue at #487.