### PR TITLE
Remove Benton override

### DIFF
--- a/docs/developer-guide/building-modules.md
+++ b/docs/developer-guide/building-modules.md
@@ -220,7 +220,7 @@ As an example (assuming you loaded these modules in your `bower.json`), create a
 	@import 'o-colors/main';
 
 	// Store the default FT sans-serif font stack in a variable
-	$sans-serif: oFontsGetFontFamilyWithFallbacks(BentonSans);
+	$sans-serif: oFontsGetFontFamilyWithFallbacks(Metric);
 
 	html {
 		// The iconic pink background

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,5 @@
 body {
 	margin: 0;
-	font-family: BentonSans, sans-serif;
 }
 
 .o-header {


### PR DESCRIPTION
We're calling benton but not using it.
I've also upated a code example to use metric too, though this example should
be looked at seperately to make sure it still works as I think the font stack
has changed anyway.