### PR TITLE
Add deprecation guide under docs/component-spec/

### DIFF
--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -125,9 +125,9 @@ Origami modules are generally installed based on a semver range. To ensure new r
 In the event of deprecating a module within Origami, the following steps must be followed.
 
 1. Modify `origami.json` to change the `supportStatus` to `deprecated`.
-2. Change the `README.md` to have a paragraph at the top outlining the deprecation status. It must also point to the module that has replaced the deprecated module.
+2. Change the `README.md` to have a paragraph at the top outlining the deprecation status. If it has been replaced, it must point to the new replacement module from the deprecated module.
 3. Disable the Issues functionality from the deprecated module's repository.
-4. Update the repository's description to "deprecated - please use <module> instead" and change the URL to point towards the replacement's repository on GitHub.
+4. Update the repository's description to "deprecated - please use <module> instead" if it has been replaced and change the URL to point towards the replacement's repository on GitHub.
 
 ## Themes
 

--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -120,6 +120,14 @@ Origami modules are generally installed based on a semver range. To ensure new r
 * If releasing a module that contains generated content (fonts for example), make sure the new files are in the git repository (git ls-files) at the release commit
 * Don’t make a major release until all or most dependants have removed deprecated features
 
+#### Deprecation of a module
+
+In an event of deprecating a module within Origami, the following steps will be undertaken.
+
+1. Modify `origami.json` to change the `supportStatus` from `active` to `deprecated`.
+2. Change the `README.md` to have a paragraph at the top outlining the deprecation status. It must also point to the module that has replaced the deprecated module.
+3. Disable the Issues functionality from the deprecated module's repository.
+4. Update the repository's description to "deprecated - please use <module> instead" and change the URL to point towards the replacement's repository on GitHub.
 
 ## Themes
 

--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -122,9 +122,9 @@ Origami modules are generally installed based on a semver range. To ensure new r
 
 #### Deprecation of a module
 
-In an event of deprecating a module within Origami, the following steps will be undertaken.
+In the event of deprecating a module within Origami, the following steps must be followed.
 
-1. Modify `origami.json` to change the `supportStatus` from `active` to `deprecated`.
+1. Modify `origami.json` to change the `supportStatus` to `deprecated`.
 2. Change the `README.md` to have a paragraph at the top outlining the deprecation status. It must also point to the module that has replaced the deprecated module.
 3. Disable the Issues functionality from the deprecated module's repository.
 4. Update the repository's description to "deprecated - please use <module> instead" and change the URL to point towards the replacement's repository on GitHub.


### PR DESCRIPTION
#496 

This adds a little step-by-step guide under **Managing releases** about what can be done for deprecation of a module.