### PR TITLE
Switch from Pa11y to Pa11y CI

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -1,5 +1,6 @@
 {
 	"defaults": {
+		"concurrency": 6,
 		"hideElements": ".c-search"
 	}
 }

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,5 @@
+{
+	"defaults": {
+		"hideElements": ".c-search"
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export PATH := $(NPM_BIN):$(PATH)
 # Install dependencies
 install:
 	@echo "Installing Pa11y..."
-	@npm install pa11y@^3
+	@npm install pa11y-ci@^0.2
 	@echo "Installing GitHub Pages gem..."
 	@gem install github-pages
 
@@ -24,17 +24,7 @@ serve:
 	@echo "Watching files and serving site on localhost:4000"
 	@exec jekyll serve --watch
 
-# List all of the URLs in a locally running site
-list-urls:
-	@curl -s http://$(HOST)/sitemap.xml | grep "<loc>" \
-		| sed -e 's/<loc>//g' \
-		| sed -e 's/<\/loc>//g' \
-		| sed -e "s/^\//http:\/\/$(HOST)\//g" \
-		| sort
-
 # Run pa11y against the site
 test:
 	@echo "Testing site"
-	@make list-urls | sed '/^$$/d' | { while read i; do pa11y --hide-elements ".c-search" --ignore "notice;warning" $$i || exit 1; done }
-# This is set up to fail on a page when it finds at least one accessibility error.
-# If it passes on a page, it will move onto the next until an error is found.
+	@pa11y-ci --sitemap "http://$(HOST)/sitemap.xml" --sitemap-find "^/" --sitemap-replace "http://$(HOST)/"

--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ The locally running website will be viewable here: [`http://localhost:4000/`](ht
 
 ## Testing
 
-This website is tested with [Pa11y](http://www.pally.org) using CircleCI. If there are accessibility errors on the website, the build will fail.
+This website is tested with [Pa11y CI](https://github.com/pa11y/ci) using CircleCI. If there are accessibility errors on the website, the build will fail.
 
-If you'd like to run these tests locally, you'll need [PhantomJS](http://phantomjs.org/) to be installed. You'll also need the site to be running (using `make serve`). Once these requirements have been met, you can run:
+If you'd like to run these tests locally, you'll need:
+
+  - [PhantomJS](http://phantomjs.org/) installed
+  - [Pa11y CI](https://github.com/pa11y/ci) installed (`npm install -g pa11y-ci`)
+  - The site to be running (`make serve`).
+
+You should now be able to run the following to test the site:
 
 ```sh
 make test


### PR DESCRIPTION
Pa11y CI is more geared towards what we're doing here, and it also has sitemap support built in. So we can reduce a bunch of boilerplate code.

Also the test part of the build now takes ~15s instead of ~40s as we can test multiple pages in parallel with Pa11y CI.