### PR TITLE
Update the `origami.json` guidelines with `hidden` and `display_html` properties

### DIFF
--- a/docs/syntax/origamijson.md
+++ b/docs/syntax/origamijson.md
@@ -137,10 +137,6 @@ All origami components, whether modules or web services, should be discoverable 
 	<td>array</td>
 	<td>(optional) List of strings of other modules that are only needed for one or more demos and will be loaded via the build service. They follow the same structure as how the build service works. (e.g.: "o-ft-icons@^2.3.1" or "o-ft-icons").</td>
 </tr><tr>
-	<td><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;expanded</code></td>
-	<td>boolean</td>
-	<td>(optional) Whether the demo should be shown in expanded form in the [Registry](registry.origami.ft.com).</td>
-</tr><tr>
 	<td><code>&nbsp;&nbsp;}</code></td>
 	<td></td>
 	<td></td>
@@ -151,7 +147,7 @@ All origami components, whether modules or web services, should be discoverable 
 </tr><tr>
 	<td><code>&nbsp;&nbsp;&nbsp;&nbsp;{</code></td>
 	<td>object</td>
-	<td>A config object to be applied for each demo (repeatable). Please check out the options in the [modules component spec](http://origami.ft.com/docs/component-spec/modules/#demo-config)</td>
+	<td>A config object to be applied for each demo (repeatable). Please check out the options in the <a href="http://origami.ft.com/docs/component-spec/modules/#demo-config">modules component spec</a></td>
 </tr><tr>
 	<td><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</code></td>
 	<td>string*</td>
@@ -160,6 +156,14 @@ All origami components, whether modules or web services, should be discoverable 
 	<td><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</code></td>
 	<td>string*</td>
 	<td>Explanation of the purpose of the demo.</td>
+</tr><tr>
+	<td><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hidden</code></td>
+	<td>boolean</td>
+	<td>(optional) Whether the demo should be hidden in the Registry.</td>
+</tr><tr>
+	<td><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;display_html</code></td>
+	<td>boolean</td>
+	<td>(optional) Whether the demo should have a HTML tab in the Registry (defaults to <code>true</code>).</td>
 </tr><tr>
 	<td><code>&nbsp;&nbsp;&nbsp;&nbsp;}</code></td>
 	<td></td>
@@ -184,6 +188,8 @@ All origami components, whether modules or web services, should be discoverable 
 	  "description": "Tweet module",
 	  "origamiType": "module",
 	  "origamiVersion": 1,
+	  "keywords": "twitter, tweets, social media",
+	  "origamiCategory": "component",
 	  "support": "developer@example.com",
 	  "supportStatus": "active",
 	  "browserFeatures": {
@@ -203,11 +209,16 @@ All origami components, whether modules or web services, should be discoverable 
 	  	{
 			"name": "demo1",
 			"description": "Basic module implementation",
-			"expanded": true,
 			"template": "demos/src/demo1.mustache"
+		},
+	  	{
+			"name": "pa11y",
+			"description": "Hidden test for pa11y",
+			"hidden": true,
+			"template": "demos/src/demo-pa11y.mustache"
 	  	}
 	  ],
 	  "ci": {
-	    "travis": "https://api.travis-ci.org/repos/Financial-Times/o-tweet/builds.json"
+	    "circle": "https://circleci.com/api/v1/project/Financial-Times/o-tweet"
 	  }
 	}


### PR DESCRIPTION
Also tidies up the example json at the bottom of the page.