### PR TITLE
Update the services spec to match all current services

### DIFF
--- a/docs/component-spec/web-services.md
+++ b/docs/component-spec/web-services.md
@@ -37,11 +37,11 @@ This *must* be suffixed with an environment identifier for non-production applic
 
 ### URLs
 
-Origami web services *should* exist on a path under `ft.com` if users would benefit from HTTP2 in this case. If this is not possible for some reason then a subdomain must be used.
+Origami web services *should* exist on a path under `ft.com` if users would benefit from HTTP2 in this case. If this is not possible for some reason then a subdomain *must* be used.
 
-When using a path, it should be `/__origami/service/<short-name>`. The short name in this case is the slugified service name with `origami-` and `-service` removed, E.g. `/__origami/service/build`.
+When using a path, it *should* be `/__origami/service/<short-name>`. The short name in this case is the slugified service name with `origami-` and `-service` removed, E.g. `/__origami/service/build`.
 
-When using a subdomain, it should be `<short-name>.ft.com`. The short name in this case is the slugified service name with `-service` removed, E.g. `origami-build.ft.com`.
+When using a subdomain, it *should* be `<short-name>.ft.com`. The short name in this case is the slugified service name with `-service` removed, E.g. `origami-build.ft.com`.
 
 ### Examples
 

--- a/docs/component-spec/web-services.md
+++ b/docs/component-spec/web-services.md
@@ -8,7 +8,7 @@ site_section: about-origami
 
 # Web services
 
-A **web service** component is offered as a URL endpoint that delivers content or data services. Content fragments can be included in projects either on demand on a request by request basis (using [ESI](http://en.wikipedia.org/wiki/Edge_Side_Includes) or similar technology), or by downloading the content on a regular schedule and pushing it into a local cache. Other web services may act as data collectors (for analytics) or do almost anything else. Web service components are available as raw source in git, but are not intended to be cloned or run by product developers unless they want to for testing. The component is the hosted service, rather than the application that runs it. Examples of good use cases for web services are:
+A **web service** component is offered as a URL endpoint that delivers content or data services. Web service components are available as raw source in git, but are not intended to be cloned or run by product developers unless they want to for testing. The component is the hosted service, rather than the application that runs it. Examples of good use cases for web services are:
 
   * FT Main navigation
   * Most read / shared / commented

--- a/docs/component-spec/web-services.md
+++ b/docs/component-spec/web-services.md
@@ -6,132 +6,152 @@ permalink: /docs/component-spec/web-services/
 site_section: about-origami
 ---
 
-# Web service components
+# Web services
 
-A **web service** component is offered as a URL endpoint that delivers content or data services.  Content fragments can be included in projects either on demand on a request by request basis (using [ESI](http://en.wikipedia.org/wiki/Edge_Side_Includes) or similar technology), or by downloading the content on a regular schedule and pushing it into a local cache.  Other web services may act as data collectors (for analytics) or do almost anything else.  Web service components are available as raw source in git, but are not intended to be cloned or run by product developers unless they want to for testing.  The component is the hosted service, rather than the application that runs it.  Examples of good use cases for web services are:
+A **web service** component is offered as a URL endpoint that delivers content or data services. Content fragments can be included in projects either on demand on a request by request basis (using [ESI](http://en.wikipedia.org/wiki/Edge_Side_Includes) or similar technology), or by downloading the content on a regular schedule and pushing it into a local cache. Other web services may act as data collectors (for analytics) or do almost anything else. Web service components are available as raw source in git, but are not intended to be cloned or run by product developers unless they want to for testing. The component is the hosted service, rather than the application that runs it. Examples of good use cases for web services are:
 
-* FT Main navigation
-* Most read / shared / commented
-* Jobs from exec-appointments
-* Fetching individual tweets from twitter
-* Collecting analytics
+  * FT Main navigation
+  * Most read / shared / commented
+  * Jobs from exec-appointments
+  * Fetching individual tweets from twitter
+  * Collecting analytics
+
 
 ## Naming conventions
 
-Web services source code repositories *must* be named using a short descriptive term (hypenated when appropriate), suffixed with `-service`.  The service hostname should drop the suffix.  Examples:
+Origami web services follow strict naming conventions. We name all of our services in the pattern `Origami <name> Service`, e.g. Origami Build Service, Origami Image Service.
+
+A slugified name will be used elsewhere. This is a lower case, hyphenated version of the name, e.g. origami-build-service, origami-image-service.
+
+The slugified name *must* be used as the system code for the application.
+
+Note: there may be exceptions to this naming structure in circumstances where "Service" doesn't effectively describe what the application does, e.g. with Origami Bower Registry. If you think that a different name might be required then discuss with the team.
+
+### Repositories
+
+The associated Git repository *must* be named with the slugified version of the web service name.
+
+### Heroku applications
+
+Heroku applications for a web service *must* be named with the slugified version of the web service name.
+
+This *must* be suffixed with an environment identifier for non-production applications, and a region identifier for production applications. E.g. origami-build-service-qa, origami-build-service-eu.
+
+### URLs
+
+Origami web services *should* exist on a path under `ft.com` if users would benefit from HTTP2 in this case. If this is not possible for some reason then a subdomain must be used.
+
+When using a path, it should be `/__origami/service/<short-name>`. The short name in this case is the slugified service name with `origami-` and `-service` removed, E.g. `/__origami/service/build`.
+
+When using a subdomain, it should be `<short-name>.ft.com`. The short name in this case is the slugified service name with `-service` removed, E.g. `origami-build.ft.com`.
+
+### Examples
 
 <table class="o-techdocs-table">
-<tr><th>Repo name</th><th>Host name</th></tr>
-<tr><td>tweet-service</td><td>tweet.webservices.ft.com</td></tr>
-<tr><td>nav-service</td><td>nav.webservices.ft.com</td></tr>
-<tr><td>mostpopular-service</td><td>mostpopular.webservices.ft.com</td></tr>
+	<tr>
+		<th>Service name</th>
+		<th>Repository</th>
+		<th>Heroku app</th>
+		<th>URL</th>
+	</tr>
+	<tr>
+		<td>Origami Tweet Service</td>
+		<td>origami-tweet-service</td>
+		<td>origami-tweet-service-eu</td>
+		<td><code>www.ft.com/__origami/service/tweet</code> or <code>origami-tweet.ft.com</code></td>
+	</tr>
+	<tr>
+		<td>Origami Most Popular Service</td>
+		<td>origami-most-popular-service</td>
+		<td>origami-most-popular-service-eu</td>
+		<td><code>www.ft.com/__origami/service/most-popular</code> or <code>origami-most-popular.ft.com</code></td>
+	</tr>
 </table>
 
-## API host
+<!--__ weird comment needed to fix markdown formatting -->
 
-Web services *must* expose an HTTP endpoint on the hostname `{componentname}.webservices.ft.com`, which conforms to the requirements included below.
 
 ## Requirements
 
+Many of the requirements below can be met by using Node.js and the [Origami Service module](https://github.com/Financial-Times/origami-service). We recommend this as a starting point.
+
 ### Web services *must*
-* contain a valid [Origami manifest file]({{site.baseurl}}/docs/syntax/origamijson)
-* Include a mandatory version number element to the API path for all API endpoints
-* *not* expose minor version changes in the web service application on the version number included in the API endpoint URL
-* Meet the [standard for HTML]({{site.baseurl}}/docs/syntax/html) when relevant
-* Require requests to API endpoints to contain an identification string set by the requesting application, either in a `source` query string parameter or an `X-FT-Source` HTTP header.  *Must* support the query string parameter, and *should* support the header (if header is supported and the service supports CORS, it *must* also support a pre-flight check to allow the header to be sent from foreign origins).  If neither the header nor the query param is present, *must* return a `400 Bad Request` response status code.  Requests to non-API endpoints such as the root path or /__about *should not* require the source parameter.
-* Provide monitoring endpoints and data conforming to the [FT Health page standard](https://docs.google.com/a/ft.com/document/d/18hefJjImF5IFp9WvPAm9Iq5_GmWzI9ahlKSzShpQl1s/edit)
-* When an error occurs that prevents the service returning the output requested, the HTTP response code *must* be in the 5xx or 4xx range, and:
-	* if the expected response is HTML, *must* have an empty content body unless error information has been requested via a query string parameter.  The web service *should* implement such a parameter.  If it does, the parameter *must* be called `showerrors`, and the presence of this parameter *must* always turn on visible errors unless it has a value which is set to 0;
-	* if the expected response is not HTML, *must* return error information in the content body.
-* Include an explicit `Cache-Control` header in all HTTP responses that have a 2xx or 3xx response status
-* Serve content on the bare versioned endpoints (e.g. `/v1/`) that documents the API methods available.  Documentation content thus served *should* use the `o-techdocs` module for formatting and layout.
-* Redirect the root path `/` to the documentation endpoint for the latest API version
-* Provide a mechanism for developers to subscribe to email notifications of version deprecation (which *may* be GitHub stargazers, if available).
-* When a [non-backwards compatible change](#changes-and-versioning) is made to any output of the service:
-	* provide a new set of API endpoints with updated version number; and
-	* continue to support previous versions for a minimum of 3 months; and
-	* the developer *must* begin work to agree a termination date for the previous version with its consumers and the wider business.
-* When a prior version is to be terminated,
-	* the developer *must* give at least 3 months notice via an email notification to the notification list; and
-	* the developer *must* review the top referring applications identified by the `source` argument or header and proactively notify their owners via the consuming application's runbook; and
-	* the service *must* include an `X-Service-Termination-Date:` header in all HTTP responses on that version's API endpoints, using an RFC1123 format date; and
-	* following the expiry of the termination date, and for ever more, the service *should* return either a `410 Gone` or a static copy of the last content to be generated.
+
+  * Follow the [engineering checklist](https://docs.google.com/document/d/1NbgQwJKUhSJBVMWw8OVVrKyKwRieaXq7AOtioC69XKM/edit)
+
+  * Provide the FT standard meta endpoints:
+
+    * `/__about` ([standard](https://docs.google.com/document/d/1B80a0nAI8L1cuIlSEai4Zuztq7Lef0ytxJYNFCjG7Ko/edit))
+    * `/__gtg` ([standard](https://docs.google.com/document/d/11paOrAIl9eIOqUEERc9XMaaL3zouJDdkmb-gExYFnw0/edit))
+    * `/__health` ([standard](https://docs.google.com/document/d/18hefJjImF5IFp9WvPAm9Iq5_GmWzI9ahlKSzShpQl1s/edit))
+
+  * Include a mandatory version number element to the API path for all API endpoints. This *must not* expose minor version changes and *must* be prefixed with a `v`. E.g.
+
+    * `www.ft.com/__origami/service/tweet/v1/<endpoint>`
+    * `www.ft.com/__origami/service/most-popular/v2/<endpoint>`
+    * `www.ft.com/__origami/service/jobs/v3/<endpoint>`
+
+    The only exception to this rule is when the service is replicating a third-party API. E.g. a Bower registry
+
+  * Meet the [standard for HTML]({{site.baseurl}}/docs/syntax/html) where relevant
+
+  * Require requests to API endpoints to contain an identification string set by the requesting application, in a `source` query string parameter. If the query parameter is missing, *must* return a `400 Bad Request` response status code. Requests to non-API endpoints such as the root path or `/__about` *should not* require the source parameter.
+
+    If you are using Node.js to build the service, then we provide [Express middleware to check source parameters](https://github.com/Financial-Times/source-param-middleware).
+
+  * When an error occurs that prevents the service from returning the output requested, the HTTP response code *must* be in the `5xx` or `4xx` range
+
+  * Include an explicit `Cache-Control` header in all HTTP responses that have a `2xx` or `3xx` status
+
+  * Serve content on the bare versioned endpoints (e.g. `/v1/`) that documents the service or links to documentation under a `docs` path (e.g. `/v1/docs/`). Documentation content thus served *should* use the `o-techdocs` module for formatting and layout
+
+  * Redirect the root path `/` to the documentation endpoint for the latest API version
+
+  * When a [non-backwards compatible change](#changes-and-versioning) is made to any output of the service, you *must*:
+
+    * provide a new set of API endpoints with updated version number
+    * continue to support previous versions for a minimum of 6 months
+    * communicate the deprecation of the previous version to the service consumers and the wider business
+
+  * When a prior version is to be terminated, you *must*:
+    * give at least 6 months notice via an email notification to the service consumers and the wider business
+    * review the top referring applications identified by the `source` parameter and proactively notify their owners
+    * following the expiry of the termination date, and for ever more, the service *should* return either a `410 Gone`, a static copy of the last content to be generated, or redirect to the new version if the API is compatible
 
 ### Web services *should*
-* Be used for components that produce dynamic editorial content or data that is not practical to store statically in a module component (usually because it changes too frequently or there are too many possible permutations).
-* Support both HTML and JSON output (see below for details)
-* Serve permissive CORS response headers to allow the endpoints to be consumed in-browser from any origin (though consuming in-browser is discouraged).  If CORS is supported, the service *must* support all potential pre-flight requests that would be required in the case of requests for HTTP methods other than GET, or those that send additional headers (such as `X-FT-Source`)
-* Use the querystring parameter `callback` if JSONP is supported (when returning HTML with a JSON callback, the HTML string *must* be escaped and quoted).  JSONP support is, however, not required.
-* Be RESTful, ie. should use the most appropriate HTTP verb and URLs that semantically describe the resource to be acted upon
-* Draw templates from a module component where practical (to allow product developers to consume them and do the templating themselves), and if it does, those templates *must* be Mustache format.  Conversely, templates built into the web service may be of any format.
-* Accept any querystring parameters, POST data, URL parameters or other input as desired to allow for service specific features (this may include accepting input and then simply reformatting it and including it in the output, but component developers *should* avoid doing this in services whose output also draws from other content sources).
-* *not* output any executable code (use module components for that)
-* Emit metrics to the FT graphite service.  See [Metrics](#metrics).
 
-### Output formats
+  * Be used for components that produce dynamic editorial content or data that is not practical to store statically in a module component (usually because it changes too frequently or there are too many possible permutations)
 
-Some web services provide data to include in a website (e.g. a tweet service), while others may output little more than an acknowledgement (e.g. an analytics collector).  Where a web service's output is intended to be content for inclusion in a web page, it *should* be offered as both HTML and JSON.
+  * Serve permissive CORS response headers to allow the endpoints to be consumed in-browser from any origin (though consuming in-browser is discouraged). If CORS is supported, the service *must* support all potential pre-flight requests that would be required in the case of requests for HTTP methods other than GET
+
+  * Use the querystring parameter `callback` if JSONP is supported. JSONP support is, however, not required
+
+  * Be RESTful, ie. should use the most appropriate HTTP verb and URLs that semantically describe the resource to be acted upon
+
+  * Emit metrics to the FT graphite service. See [Metrics](#metrics).
+
+  * Use the [Origami Service module](https://github.com/Financial-Times/origami-service) if the service is built with Node.js
 
 ### Changes and versioning
 
-A "backwards compatible change" is defined as one that, in the case of JSON output, adds a new property to an object, or adds or removes elements from an array.  Any changes that remove existing properties of objects, or change the type of a value, are breaking.  In the case of HTML output, any change that requires accompanying changes in a module component (CSS, JavaScript or other resources that act on the HTML) is breaking.
+A "backwards compatible change" is defined as one that, in the case of JSON output, adds a new property to an object, or adds or removes elements from an array. Any changes that remove existing properties of objects, or change the type of a value, are breaking. In the case of HTML output, any change that requires accompanying changes in a module component (CSS, JavaScript or other resources that act on the HTML) is breaking.
 
 In the case of breaking changes, a service *must* maintain the existing functionality and release a new version.
 
-When a new version of a web service is released, the service developer *may* choose to implement this by running multiple versions of the service behind a routing layer, such that `/v1/someendpoint` and `/v2/someendpoint` ultimately result in the same `/someendpoint` request being made to one or other of two separate instances of the web service.  This is acknowledged as a valid approach, but other web service developers *may* simply wish to run one instance of the web service that can handle all versioned endpoints.  This spec does not care about the internal architecture choices that the web service developer makes provided that the external interface satisfies the requirements set out above.
-
-### Environments
-
-A web service component developer *must* make available a live instance of their service (which *should* be at `{componentname}.webservices.ft.com`), the source code (in a git repo), and instructions for building and running the service.
-
-If the web service uses a data source or other depended-upon service for which multiple environments are available, the service *must* support switching between them at startup (either using a command line flag, or a config file, but either way it must be included in the documentation)
-
-The product developer *must* use the current live version of the component for testing integration with their product, not an upcoming release or a test or dev environment of the service.  The service component developer is not required to (and is encouraged not to) maintain and make available any running instance of the service other than the live one.
-
-Instructing a service to use a different (e.g. test) data source *must not* be coupled in any way to using a different version of the service itself.
-
-### Required endpoints
-
-Web services *must* implement the following endpoints, for each version of the application, as well as at the root of the service host (except for `/__about` - see below). The root variant *may* redirect to the latest version variant, or *may* simply produce the same output as the latest version variant.  It is also OK to output the same data for all version variants if the data has not changed between versions.
-
-<table class="o-techdocs-table">
-<tr><td><code>/</code></td><td>Description of the service and instructions for use, designed for human consumption.  This <em>should</em> be HTML, and <em>may</em> choose to use the standard Origami documentation stylesheet.</td></tr>
-<tr><td><code>/__health</code></td><td>Health status JSON data conforming to the <a href="https://docs.google.com/a/ft.com/document/d/18hefJjImF5IFp9WvPAm9Iq5_GmWzI9ahlKSzShpQl1s/edit">FT Health check standard</a>.  Note that the health check standard currently requires the alerts to be output in a 'human readable' form, and that may require implementing additional endpoints (or reformatting at the edge)</td></tr>
-<tr><td><code>/__about</code></td><td><em>(root only)</em> A JSON document linking to all available versions of the service, in the <a href='{{site.baseurl}}/docs/syntax/web-service-index'>web service index format</a><br/><em>(version endpoints only)</em> A JSON document in the <a href='{{site.baseurl}}/docs/syntax/web-service-description'>web service description format</a></td></tr>
-</table>
-
-If a web service has two versions, `v1` and `v2`, there *must* be three of each of the above.  Using the `/health` endpoint as an example, the complete paths `/__health`, `/v1/__health` and `/v2/__health` *must* be recognised and served by the web service, and *may* return the same content.  The `__about` data *must* also be available from three URLs, but will follow the [web service description format]({{site.baseurl}}/docs/syntax/web-service-description) format for those that are version prefixed, and the [web service index]({{site.baseurl}}/docs/syntax/web-service-index) format for the one that isn't.
+When a new version of a web service is released, the service developer *may* choose to implement this by running multiple versions of the service behind a routing layer, such that `/v1/someendpoint` and `/v2/someendpoint` ultimately result in the same `/someendpoint` request being made to one or other of two separate instances of the web service. This is acknowledged as a valid approach, but other web service developers *may* simply wish to run one instance of the web service that can handle all versioned endpoints. This spec does not care about the internal architecture choices that the web service developer makes provided that the external interface satisfies the requirements set out above.
 
 ### De-duplication of output
 
-Web service components *should not* offer any de-duplication of content.  If a product developer wants to draw from multiple Origami sources, and de-dupe where the same individual content item may appear from more than one of those sources, that's not a problem that Origami will solve for them, but could be solved at the product level by consuming data rather than markup.
+Web service components *should not* offer any de-duplication of content. If a product developer wants to draw from multiple Origami sources, and de-dupe where the same individual content item may appear from more than one of those sources, that's not a problem that Origami will solve for them, but could be solved at the product level by consuming data rather than markup.
+
 
 ## Metrics
 
-Web service components *should* emit metrics over TCP using the [Carbon plaintext protocol](http://graphite.readthedocs.org/en/latest/feeding-carbon.html), to the FT Graphite service.  All metrics *must* conform to the [metrics naming conventions]({{site.baseurl}}/docs/syntax/metrics).
+Web service components *should* emit metrics over TCP using the [Carbon plaintext protocol](http://graphite.readthedocs.org/en/latest/feeding-carbon.html), to the FT Graphite service. All metrics *must* conform to the [metrics naming conventions]({{site.baseurl}}/docs/syntax/metrics).
 
 Web services *should* send metrics no more frequently than every 5 seconds, and should consult the monitoring team before sending more than 100,000 data points per hour.
 
-### Client libraries
-
-The following client libraries make submitting metrics easier:
-
-<table class="o-techdocs-table">
-<thead><tr><th>Language</th><th>Tools</th><th>Example uses</th></tr></thead>
-<tbody>
-	<tr>
-		<td>NodeJS / IOJS</td>
-		<td>
-			<a href='https://github.com/felixge/node-graphite'>node-graphite</a>,
-			<a href='https://github.com/felixge/node-measured'>node-measured</a>
-		</td>
-		<td>
-			<a href='https://github.com/Financial-Times/polyfill-service/blob/master/service/metrics.js'>polyfill-service</a>
-		</td>
-	</tr>
-</tbody>
-</table>
-
+Metrics are provided by default with the [Origami Service module](https://github.com/Financial-Times/origami-service).
 
 
 ## Example

--- a/docs/component-spec/web-services.md
+++ b/docs/component-spec/web-services.md
@@ -95,6 +95,8 @@ Many of the requirements below can be met by using Node.js and the [Origami Serv
 
   * Require requests to API endpoints to contain an identification string set by the requesting application, in a `source` query string parameter. If the query parameter is missing, *must* return a `400 Bad Request` response status code. Requests to non-API endpoints such as the root path or `/__about` *should not* require the source parameter.
 
+    The only exception to this rule is when the service is replicating a third-party API. E.g. a Bower registry
+
     If you are using Node.js to build the service, then we provide [Express middleware to check source parameters](https://github.com/Financial-Times/source-param-middleware).
 
   * When an error occurs that prevents the service from returning the output requested, the HTTP response code *must* be in the `5xx` or `4xx` range

--- a/docs/component-spec/web-services.md
+++ b/docs/component-spec/web-services.md
@@ -10,11 +10,9 @@ site_section: about-origami
 
 A **web service** component is offered as a URL endpoint that delivers content or data services. Web service components are available as raw source in git, but are not intended to be cloned or run by product developers unless they want to for testing. The component is the hosted service, rather than the application that runs it. Examples of good use cases for web services are:
 
-  * FT Main navigation
-  * Most read / shared / commented
-  * Jobs from exec-appointments
-  * Fetching individual tweets from twitter
-  * Collecting analytics
+  * [Serving optimised images](https://www.ft.com/__origami/service/image)
+  * [Serving JS/CSS bundles of Origami components](https://www.ft.com/__origami/service/build)
+  * [Providing standard navigation data](https://www.ft.com/__origami/service/navigation)
 
 
 ## Naming conventions


### PR DESCRIPTION
None of our services were meeting the spec, including the older
ones. I've updated the spec to include new standards that we employ, and
to reflect the way we're actually building services.