### PR TITLE
Copy change - take brackets out of navigation text

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,16 +15,16 @@
 							<a href="{{ site.baseurl }}/docs/developer-guide/modules/">Modules documentation</a>
 							<ul class="o-techdocs-nav o-techdocs-nav--sub">
 								<li{% if page.title == 'Origami modules quick start' %} aria-selected="true"{% endif %}>
-									<a href="{{ site.baseurl }}/docs/developer-guide/modules/very-quick-origami/">(tutorial) Modules quick start</a>
+									<a href="{{ site.baseurl }}/docs/developer-guide/modules/very-quick-origami/">TUTORIAL Quick start</a>
 								</li>
 								<li{% if page.title == 'How to pick your build method' %} aria-selected="true"{% endif %}>
 									<a href="{{ site.baseurl }}/docs/developer-guide/modules/choosing-your-build-method/">How to pick your build method</a>
 								</li>
 								<li{% if page.title == 'Build Service guide' %} aria-selected="true"{% endif %}>
-									<a href="{{ site.baseurl }}/docs/developer-guide/modules/build-service/">(tutorial) Using the Build Service</a>
+									<a href="{{ site.baseurl }}/docs/developer-guide/modules/build-service/">TUTORIAL The Build Service</a>
 								</li>
 								<li{% if page.title == 'Manual build process guide' %} aria-selected="true"{% endif %}>
-									<a href="{{ site.baseurl }}/docs/developer-guide/modules/building-modules/">(tutorial) Using a manual build process</a>
+									<a href="{{ site.baseurl }}/docs/developer-guide/modules/building-modules/">TUTORIAL Manual build process</a>
 								</li>
 								<li{% if page.title == 'Initialising modules' %} aria-selected="true"{% endif %}>
 									<a href="{{ site.baseurl }}/docs/developer-guide/modules/initialising-modules/">How to initialise modules</a>


### PR DESCRIPTION
Brackets are a bit confusing in headings, so switching them to capitals. 
I have also shortened the navigation headings from `Modules quick start` to `Quick start`. And from `Using the build service` to `Build service`. 

<img width="282" alt="screen shot 2017-09-27 at 11 36 38" src="https://user-images.githubusercontent.com/10324129/30909214-3a3e9592-a378-11e7-9860-0597aa0939b7.png">
